### PR TITLE
Update linker flags to include max-page-size option

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(
 # loads the NitroModules shared library. This is required because we're
 # building a library that depends on NitroModules symbols which are only
 # available at runtime.
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--allow-shlib-undefined")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--allow-shlib-undefined,-z,max-page-size=16384")
 
 # Include Nitrogen autolinking - this adds all generated sources and links
 include(${CMAKE_SOURCE_DIR}/../nitrogen/generated/android/LiteRTLM+autolinking.cmake)


### PR DESCRIPTION
Added '-z,max-page-size=16384' to linker flags for shared library.

Android expects 16 KB memory page size from Nov 2025 for Play Store compatibility: https://developer.android.com/guide/practices/page-sizes