### PR TITLE
feat: add configurable vision and audio backends to LLM configuration

### DIFF
--- a/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
+++ b/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
@@ -124,6 +124,8 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
 
     // Configuration
     private var backend: Backend = Backend.CPU
+    private var visionBackend: Backend? = null
+    private var audioBackend: Backend? = null
     private var temperature: Double = 0.7
     private var topK: Int = 40
     private var topP: Double = 0.95
@@ -153,6 +155,8 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
                 // Apply configuration
                 config?.let { cfg ->
                     cfg.backend?.let { backend = it }
+                    cfg.visionBackend.let {visionBackend = it}
+                    cfg.audioBackend.let {audioBackend = it}
                     cfg.temperature?.let { temperature = it }
                     cfg.topK?.let { topK = it.toInt() }
                     cfg.topP?.let { topP = it }
@@ -171,13 +175,19 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
                         else -> com.google.ai.edge.litertlm.Backend.CPU()
                     }
                     
-                    // Vision backend: hardcoded to GPU (required by Gemma models)
-                    val lmVisionBackend = com.google.ai.edge.litertlm.Backend.GPU()
-                        
-                    // Audio backend: hardcoded to CPU (optimal for audio processing)
-                    val lmAudioBackend = com.google.ai.edge.litertlm.Backend.CPU()
+                    val lmVisionBackend = when (visionBackend) {
+                        Backend.GPU -> com.google.ai.edge.litertlm.Backend.GPU()
+                        Backend.CPU -> com.google.ai.edge.litertlm.Backend.CPU()
+                        else -> null
+                    }
+
+                    val lmAudioBackend= when (audioBackend) {
+                        Backend.GPU -> com.google.ai.edge.litertlm.Backend.GPU()
+                        Backend.CPU -> com.google.ai.edge.litertlm.Backend.CPU()
+                        else -> null
+                    }
     
-                    Log.i(TAG, "Backend config: main=$lmBackend, vision=$lmVisionBackend (hardcoded), audio=$lmAudioBackend (hardcoded)")
+                    Log.i(TAG, "Backend config: main=$lmBackend, vision=$lmVisionBackend, audio=$lmAudioBackend")
     
                     // Get cache directory from application context
                     val cacheDirectory = LiteRTLMInitProvider.applicationContext?.cacheDir?.absolutePath

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -73,6 +73,8 @@ export function useModel(
   const enableMemoryTracking = config?.enableMemoryTracking ?? false;
   const maxMemorySnapshots = config?.maxMemorySnapshots ?? 256;
   const backend = config?.backend;
+  const visionBackend = config?.visionBackend;
+  const audioBackend = config?.audioBackend;
   const systemPrompt = config?.systemPrompt;
   const maxTokens = config?.maxTokens;
   const temperature = config?.temperature;
@@ -83,13 +85,15 @@ export function useModel(
   const nativeConfig = useMemo<LLMConfig>(
     () => ({
       ...(backend !== undefined && { backend }),
+      ...(visionBackend !== undefined && { visionBackend }),
+      ...(audioBackend !== undefined && { audioBackend }),
       ...(systemPrompt !== undefined && { systemPrompt }),
       ...(maxTokens !== undefined && { maxTokens }),
       ...(temperature !== undefined && { temperature }),
       ...(topK !== undefined && { topK }),
       ...(topP !== undefined && { topP }),
     }),
-    [backend, systemPrompt, maxTokens, temperature, topK, topP],
+    [backend, visionBackend, audioBackend, systemPrompt, maxTokens, temperature, topK, topP],
   );
 
   /**

--- a/src/specs/LiteRTLM.nitro.ts
+++ b/src/specs/LiteRTLM.nitro.ts
@@ -37,13 +37,27 @@ export interface LLMConfig {
    * If not specified, defaults to 'cpu'.
    * If specified backend is unavailable, falls back automatically.
    *
-   * @remarks
-   * Vision encoder is always set to GPU (required by Gemma models).
-   * Audio encoder is always set to CPU (optimal for audio processing).
-   *
    * @default 'cpu'
    */
   backend?: Backend;
+
+  /**
+   * Compute backend for vision/multimodal encoder.
+   * - 'cpu': CPU inference (slower, more compatible)
+   * - 'gpu': GPU acceleration (recommended, required by Gemma models)
+   *
+   * @default null
+   */
+  visionBackend?: Backend | null;
+
+  /**
+   * Compute backend for audio encoder.
+   * - 'cpu': CPU inference (optimal for audio processing)
+   * - 'gpu': GPU acceleration
+   *
+   * @default null
+   */
+  audioBackend?: Backend | null;
 
   /**
    * Maximum number of tokens to generate.


### PR DESCRIPTION
Hardcoding to GPU will crash non-multimodal models with TF_VISION_ENCODER not found error. Set default vision and audio backends to null.