### PR TITLE
Add engine validation and refactor system prompt handling

### DIFF
--- a/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
+++ b/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
@@ -198,6 +198,9 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
                     cfg.systemPrompt?.let { systemPrompt = it }
                 }
     
+                // Whether to run engine validation after loading
+                val shouldValidate = config?.validate?: false
+    
                 try {
                     // Early GPU hardware check: probe for OpenCL library before
                     // spending time on engine creation. LiteRT-LM's GPU delegate
@@ -284,8 +287,17 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
                     Log.i(TAG, "Conversation created successfully")
 
                     // Validate the engine actually works with a quick test inference.
-                    // GPU backend can initialize without error but silently fail to produce tokens.
-                    validateEngine()
+                    // GPU/NPU backends can initialize without error but silently fail to
+                    // produce tokens — enabling this catches those failures at load time.
+                    // CPU is always reliable so validation is never run on it, even when
+                    // the `validate` flag is set.
+                    if (shouldValidate) {
+                        if (backend == Backend.GPU || backend == Backend.NPU) {
+                            validateEngine()
+                        } else {
+                            Log.i(TAG, "Validation skipped: CPU backend is always reliable")
+                        }
+                    }
     
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to load model: ${e.message}", e)
@@ -676,19 +688,9 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
 
     private fun cleanupInternal() {
         try {
+            conversation?.close()
             conversation = null
-            // Explicitly close engine if it supports it to free native memory immediately
-            // Assuming Engine implements AutoCloseable or has close()
-            if (engine is AutoCloseable) {
-                (engine as AutoCloseable).close()
-            } else {
-                 // Try reflection or just null it if no close method
-                try {
-                    engine?.javaClass?.getMethod("close")?.invoke(engine)
-                } catch (e: Exception) {
-                    // Method not found, rely on GC
-                }
-            }
+            engine?.close()        // Direct call
             engine = null 
         } catch (e: Exception) {
             Log.e(TAG, "Error closing resources", e)
@@ -721,26 +723,12 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
         val convConfig = ConversationConfig(
             samplerConfig = SamplerConfig(
                 topK = topK,
-                topP = topP,
-                temperature = temperature,
-            )
+                topP = topP.toDouble(),
+                temperature = temperature.toDouble(),
+            ),
+            systemInstruction = systemPrompt?.let { Contents.of(Content.Text(it)) }
         )
         conversation = engine!!.createConversation(convConfig)
-        // Apply system prompt/instruction if set
-        systemPrompt?.let { prompt ->
-            if (prompt.isNotEmpty()) {
-                try {
-                    // Send system instruction as the first turn to prime the conversation.
-                    // LiteRT-LM's Conversation API handles chat template formatting,
-                    // including Gemma's <start_of_turn>system block.
-                    val systemMsg = LiteRTMessage.system(prompt)
-                    conversation!!.sendMessage(message = systemMsg)
-                    Log.i(TAG, "System prompt applied (${prompt.length} chars)")
-                } catch (e: Exception) {
-                    Log.w(TAG, "Failed to apply system prompt: ${e.message}")
-                }
-            }
-        }
     }
 
     /**

--- a/android/src/main/java/dev/litert/litertlm/LiteRTLMPackage.kt
+++ b/android/src/main/java/dev/litert/litertlm/LiteRTLMPackage.kt
@@ -1,18 +1,35 @@
 package dev.litert.litertlm
 
+import android.os.Build
+import android.util.Log
 import com.facebook.react.TurboReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
-import com.margelo.nitro.core.HybridObject
 
 
 import com.margelo.nitro.dev.litert.litertlm.LiteRTLMOnLoad
 
 class LiteRTLMPackage : TurboReactPackage() {
+    companion object {
+        private const val TAG = "LiteRTLMPackage"
+
+        private fun isSupportedPrimaryAbi(): Boolean {
+            val primaryAbi = Build.SUPPORTED_64_BIT_ABIS.firstOrNull() ?: return false
+            return primaryAbi == "arm64-v8a"
+        }
+    }
     init {
-        LiteRTLMOnLoad.initializeNative()
+        if (!isSupportedPrimaryAbi()) {
+            Log.w(TAG, "Skipping LiteRTLM native init on unsupported primary ABI: ${Build.SUPPORTED_64_BIT_ABIS.firstOrNull()}")
+        } else {
+            try {
+                LiteRTLMOnLoad.initializeNative()
+            } catch (e: UnsatisfiedLinkError) {
+                Log.e(TAG, "LiteRTLM native init failed; disabling LiteRTLM for this process.", e)
+            }
+        }
     }
 
 

--- a/src/specs/LiteRTLM.nitro.ts
+++ b/src/specs/LiteRTLM.nitro.ts
@@ -68,6 +68,23 @@ export interface LLMConfig {
    * @default 0.95
    */
   topP?: number;
+
+  /**
+   * Whether to run engine validation after loading the model.
+   * When enabled, sends a quick test inference ("Hi") and waits up to 30s
+   * for a response to confirm the backend works. This is useful for GPU/NPU
+   * backends that may silently fail during inference (they can initialize
+   * without error but produce no tokens).
+   *
+   * Validation is **always a no-op on CPU** — the CPU backend is inherently
+   * reliable and never needs validation.
+   *
+   * Disabled by default because it adds significant latency (5-30s) to model loading.
+   * Enable only to catch GPU/NPU silent failure issues during development.
+   *
+   * @default false
+   */
+  validate?: boolean;
 }
 
 /**


### PR DESCRIPTION
## PR Summary: Optional engine validation + Android ABI safety

### What's changed

**1. Optional engine validation (`src/specs/LiteRTLM.nitro.ts`, `HybridLiteRTLM.kt`)**
- Added a new `validate?: boolean` option to `LLMConfig` (defaults to `false`)
- Catches GPU/NPU backends that initialize successfully but silently fail to produce tokens
- Automatically skipped on CPU (always reliable)
 
**2. cleanupInternal**
- Using close method for conversation and engine. This pattern is used in AI Edge Gallery.

**3. System prompt handling**
- Set system prompt inside the sampleconfig just like how AI Edge Gallery handles it. This change massively reduces the model loading time 🎉 as we aren't running an inference to set the system instruction.

**3. Android ABI safety guard (`LiteRTLMPackage.kt`)**
- Wraps `LiteRTLMOnLoad.initializeNative()` in an `isSupportedPrimaryAbi()` check that only allows init on `arm64-v8a` devices
- Catches `UnsatisfiedLinkError` to prevent crashes on unsupported architectures
- Logs a warning when skipping init due to unsupported ABI