### PR TITLE
fix(android): add libvndksupport.so native library declaration

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -12,5 +12,8 @@
         <uses-native-library
             android:name="libOpenCL.so"
             android:required="false" />
+        <uses-native-library
+            android:name="libvndksupport.so"
+            android:required="false" />
     </application>
 </manifest>


### PR DESCRIPTION
## Summary

- Adds `libvndksupport.so` as an optional `<uses-native-library>` entry in the Android Manifest alongside the existing OpenCL declaration
  - referenced for https://ai.google.dev/edge/litert-lm/android
- Required for GPU delegate support on vendor-specific NNAPI/OpenCL loader stacks on Android 12+ devices; omitting it causes silent fallback to CPU on affected hardware

## Test plan

- [ ] Build succeeds on Android 12+ device
- [ ] GPU delegate initializes correctly on hardware that requires `libvndksupport.so` (e.g. devices with vendor NNAPI stacks)

It is working GPU Backend for my mediatek devices.(Xiaomi 15T pro /  MediaTek Dimensity 9400+)