### PR TITLE
feat: add streaming multimodal async API (sendMessageWithImageAsync / sendMessageWithAudioAsync)

### DIFF
--- a/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
+++ b/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
@@ -501,6 +501,75 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
         }
     }
 
+    override fun sendMessageWithImageAsync(message: String, imagePath: String, onToken: (String, Boolean) -> Unit): Promise<Unit> {
+        return Promise.parallel {
+            val latch = CountDownLatch(1)
+            val errorRef = AtomicReference<Throwable?>(null)
+
+            ensureLoaded()
+
+            Log.i(TAG, "sendMessageWithImageAsync: $message, path=$imagePath")
+
+            // Resize image to prevent OOM on high-resolution photos
+            val processedImagePath = resizeImageIfNeeded(imagePath)
+
+            val fullResponseBuilder = StringBuilder()
+            
+            val listener = StreamingCallbackListener(
+                onToken = { token, done ->
+                    onToken(token, done)
+                    if (done) {
+                        latch.countDown()
+                    }
+                },
+                responseBuilder = fullResponseBuilder,
+                history = history,
+                userMessage = message,
+                onStatsReady = { stats -> lastStats = stats },
+            )
+
+            try {
+                val textContent = Content.Text(message)
+                val userMsg = LiteRTMessage.user(Contents.of(textContent, Content.ImageFile(processedImagePath)))
+
+                history.add(Message(Role.USER, "$message [Image]"))
+
+                conversation!!.sendMessageAsync(message = userMsg, callback = listener)
+            } catch (e: Exception) {
+                // Clean up temp resized image to prevent cache dir bloat
+                if (processedImagePath != imagePath) {
+                    try {
+                        java.io.File(processedImagePath).delete()
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Failed to clean up temp image: ${e.message}")
+                    }
+                }
+
+                Log.e(TAG, "Failed to initiate async multimodal generation", e)
+                errorRef.set(e)
+                onToken("Error: ${e.message}", true)
+                latch.countDown()
+            }
+
+            // Wait for completion or error
+            latch.await()
+
+            // Clean up temp resized image to prevent cache dir bloat
+            if (processedImagePath != imagePath) {
+                try {
+                    java.io.File(processedImagePath).delete()
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to clean up temp image: ${e.message}")
+                }
+            }
+
+            val err = errorRef.get()
+            if (err != null) {
+                throw RuntimeException("Async multimodal inference failed: ${err.message}", err)
+            }
+        }
+    }
+
     override fun downloadModel(url: String, fileName: String, onProgress: ((Double) -> Unit)?): Promise<String> {
         return Promise.parallel {
             Log.i(TAG, "downloadModel: $url -> $fileName")
@@ -619,6 +688,54 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
                 }
             } else {
                 Log.w(TAG, "Model not found for deletion: ${modelFile.absolutePath}")
+            }
+        }
+    }
+
+    override fun sendMessageWithAudioAsync(message: String, audioPath: String, onToken: (String, Boolean) -> Unit): Promise<Unit> {
+        return Promise.parallel {
+            val latch = CountDownLatch(1)
+            val errorRef = AtomicReference<Throwable?>(null)
+
+            ensureLoaded()
+
+            Log.i(TAG, "sendMessageWithAudioAsync: $message, path=$audioPath")
+
+            val fullResponseBuilder = StringBuilder()
+
+            val listener = StreamingCallbackListener(
+                onToken = { token, done ->
+                    onToken(token, done)
+                    if (done) {
+                        latch.countDown()
+                    }
+                },
+                responseBuilder = fullResponseBuilder,
+                history = history,
+                userMessage = message,
+                onStatsReady = { stats -> lastStats = stats },
+            )
+
+            try {
+                val userMsg = LiteRTMessage.user(Contents.of(
+                    Content.Text(message),
+                    Content.AudioFile(audioPath)
+                ))
+
+                history.add(Message(Role.USER, "$message [Audio]"))
+
+                conversation!!.sendMessageAsync(message = userMsg, callback = listener)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to initiate async audio generation", e)
+                errorRef.set(e)
+                onToken("Error: ${e.message}", true)
+                latch.countDown()
+            }
+
+            latch.await()
+            val err = errorRef.get()
+            if (err != null) {
+                throw RuntimeException("Async audio inference failed: ${err.message}", err)
             }
         }
     }

--- a/android/src/test/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLMTest.kt
+++ b/android/src/test/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLMTest.kt
@@ -70,6 +70,28 @@ class HybridLiteRTLMTest {
     }
 
     @Test
+    fun testSendMessageWithImageAsyncRejectsWithoutModel() {
+        val promise = bridge.sendMessageWithImageAsync("hello", "/tmp/image.jpg") { _, _ -> }
+        assertNotNull("Promise should not be null", promise)
+        assertTrue("Promise should be completed", promise.isCompleted)
+        assertNotNull("Promise should have rejected without model", promise.error)
+        val errMsg = promise.error!!.message ?: promise.error!!.cause?.message ?: ""
+        assertTrue("Expected no-model error, got: $errMsg",
+            errMsg.contains("No model loaded"))
+    }
+
+    @Test
+    fun testSendMessageWithAudioAsyncRejectsWithoutModel() {
+        val promise = bridge.sendMessageWithAudioAsync("hello", "/tmp/audio.wav") { _, _ -> }
+        assertNotNull("Promise should not be null", promise)
+        assertTrue("Promise should be completed", promise.isCompleted)
+        assertNotNull("Promise should have rejected without model", promise.error)
+        val errMsg = promise.error!!.message ?: promise.error!!.cause?.message ?: ""
+        assertTrue("Expected no-model error, got: $errMsg",
+            errMsg.contains("No model loaded"))
+    }
+
+    @Test
     fun testAndroidInitialStats() {
         val stats = bridge.getStats()
         assertNotNull(stats)

--- a/ios/HybridLiteRTLM.swift
+++ b/ios/HybridLiteRTLM.swift
@@ -542,7 +542,285 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
         
         return promise
     }
+
+    public func sendMessageWithImageAsync(message: String, imagePath: String, onToken: @escaping (_ token: String, _ done: Bool) -> Void) throws -> Promise<Void> {
+        let promise = Promise<Void>()
+        
+        queue.async {
+            guard let conversation = self.conversation else {
+                promise.reject(withError: NSError(domain: "LiteRTLM", code: 400, userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: No model loaded. Call loadModel() first."]))
+                return
+            }
+            
+            if !FileManager.default.fileExists(atPath: imagePath) {
+                promise.reject(withError: NSError(domain: "LiteRTLM", code: 404, userInfo: [NSLocalizedDescriptionKey: "Image file not found: \(imagePath)"]))
+                return
+            }
+            
+            let msgJson = self.buildImageMessageJson(text: message, imagePath: imagePath)
+            let startTime = Date()
+            
+            let historyUserContent = message + " [image: \(imagePath)]"
+            let context = StreamContext(
+                userMessage: message,
+                startTime: startTime,
+                onToken: onToken,
+                promise: promise,
+                parent: self
+            )
+            
+            let callbackData = Unmanaged.passRetained(context).toOpaque()
+            
+            let callback: LiteRtLmStreamCallback = { callbackData, chunk, isFinal, errorMsg in
+                guard let callbackData = callbackData else { return }
+                let ctx = Unmanaged<StreamContext>.fromOpaque(callbackData).takeUnretainedValue()
+                
+                if let errorMsg = errorMsg {
+                    let errorStr = String(cString: errorMsg)
+                    ctx.onToken("Error: \(errorStr)", true)
+                    ctx.promise.reject(withError: NSError(domain: "LiteRTLM", code: 500, userInfo: [NSLocalizedDescriptionKey: errorStr]))
+                    Unmanaged<StreamContext>.fromOpaque(callbackData).release()
+                    return
+                }
+                
+                if isFinal {
+                    let endTime = Date()
+                    let totalTime = endTime.timeIntervalSince(ctx.startTime)
+                    
+                    let cleaned = ctx.parent.stripControlTokens(ctx.rawResponse)
+                    var finalCleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !ctx.userMessage.isEmpty && finalCleaned.hasPrefix(ctx.userMessage) {
+                        finalCleaned = String(finalCleaned.dropFirst(ctx.userMessage.count))
+                            .trimmingCharacters(in: .whitespacesAndNewlines)
+                    }
+                    
+                    if finalCleaned.count > ctx.lastEmittedLength {
+                        let startIdx = finalCleaned.index(finalCleaned.startIndex, offsetBy: ctx.lastEmittedLength)
+                        let remaining = String(finalCleaned[startIdx...])
+                        ctx.onToken(remaining, false)
+                    }
+                    ctx.fullResponse = finalCleaned
+                    
+                    var completionTokens = Double(ctx.tokenCount)
+                    var tokensPerSecond = 0.0
+                    var ttft = 0.0
+                    if let benchInfo = litert_lm_conversation_get_benchmark_info(ctx.parent.conversation) {
+                        let numDecodeTurns = litert_lm_benchmark_info_get_num_decode_turns(benchInfo)
+                        if numDecodeTurns > 0 {
+                            let lastIdx = numDecodeTurns - 1
+                            tokensPerSecond = litert_lm_benchmark_info_get_decode_tokens_per_sec_at(benchInfo, lastIdx)
+                            completionTokens = Double(litert_lm_benchmark_info_get_decode_token_count_at(benchInfo, lastIdx))
+                        }
+                        ttft = litert_lm_benchmark_info_get_time_to_first_token(benchInfo)
+                        litert_lm_benchmark_info_delete(benchInfo)
+                    }
+
+                    let promptTokens = Double(ctx.userMessage.count) / 4.0
+                    if completionTokens == 0.0 {
+                        completionTokens = Double(ctx.fullResponse.count) / 4.0
+                    }
+                    ctx.parent.lastStats = GenerationStats(
+                        promptTokens: promptTokens,
+                        completionTokens: completionTokens,
+                        totalTokens: promptTokens + completionTokens,
+                        timeToFirstToken: ttft,
+                        totalTime: totalTime,
+                        tokensPerSecond: tokensPerSecond > 0.0 ? tokensPerSecond : (completionTokens / totalTime)
+                    )
+                    ctx.parent.history.append(Message(role: .user, content: historyUserContent))
+                    ctx.parent.history.append(Message(role: .model, content: ctx.fullResponse))
+                    ctx.onToken("", true)
+                    ctx.promise.resolve()
+                    Unmanaged<StreamContext>.fromOpaque(callbackData).release()
+                    return
+                }
+
+                if let chunk = chunk {
+                    let token = String(cString: chunk)
+                    let raw: String
+                    if token.hasPrefix("{") && token.contains("\"role\"") {
+                        raw = ctx.parent.extractTextFromResponse(token)
+                    } else {
+                        raw = token
+                    }
+
+                    ctx.rawResponse += raw
+                    let cleaned = ctx.parent.stripControlTokens(ctx.rawResponse)
+                        .trimmingLeadingCharacters(in: .whitespacesAndNewlines)
+
+                    var processed = cleaned
+                    if !ctx.userMessage.isEmpty && processed.hasPrefix(ctx.userMessage) {
+                        processed = String(processed.dropFirst(ctx.userMessage.count))
+                            .trimmingLeadingCharacters(in: .whitespacesAndNewlines)
+                    }
+
+                    let safeLen = ctx.parent.safeEmitLength(processed)
+                    if safeLen > ctx.lastEmittedLength {
+                        let chars = Array(processed)
+                        let newText = String(chars[ctx.lastEmittedLength..<safeLen])
+                        ctx.lastEmittedLength = safeLen
+                        ctx.tokenCount += 1
+                        ctx.onToken(newText, false)
+                    }
+                }
+            }
+
+            let status = litert_lm_conversation_send_message_stream(
+                conversation,
+                msgJson,
+                nil,
+                nil,
+                callback,
+                callbackData
+            )
+            if status != 0 {
+                Unmanaged<StreamContext>.fromOpaque(callbackData).release()
+                promise.reject(withError: NSError(domain: "LiteRTLM", code: Int(status), userInfo: [NSLocalizedDescriptionKey: "Failed to start streaming conversation."]))
+            }
+        }
+
+        return promise
+    }
     
+    public func sendMessageWithAudioAsync(message: String, audioPath: String, onToken: @escaping (_ token: String, _ done: Bool) -> Void) throws -> Promise<Void> {
+        let promise = Promise<Void>()
+
+        queue.async {
+            guard let conversation = self.conversation else {
+                promise.reject(withError: NSError(domain: "LiteRTLM", code: 400, userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: No model loaded. Call loadModel() first."]))
+                return
+            }
+
+            if !FileManager.default.fileExists(atPath: audioPath) {
+                promise.reject(withError: NSError(domain: "LiteRTLM", code: 404, userInfo: [NSLocalizedDescriptionKey: "Audio file not found: \(audioPath)"]))
+                return
+            }
+
+            let msgJson = self.buildAudioMessageJson(text: message, audioPath: audioPath)
+            let startTime = Date()
+
+            let historyUserContent = message + " [audio: \(audioPath)]"
+            let context = StreamContext(
+                userMessage: message,
+                startTime: startTime,
+                onToken: onToken,
+                promise: promise,
+                parent: self
+            )
+
+            let callbackData = Unmanaged.passRetained(context).toOpaque()
+
+            let callback: LiteRtLmStreamCallback = { callbackData, chunk, isFinal, errorMsg in
+                guard let callbackData = callbackData else { return }
+                let ctx = Unmanaged<StreamContext>.fromOpaque(callbackData).takeUnretainedValue()
+
+                if let errorMsg = errorMsg {
+                    let errorStr = String(cString: errorMsg)
+                    ctx.onToken("Error: \(errorStr)", true)
+                    ctx.promise.reject(withError: NSError(domain: "LiteRTLM", code: 500, userInfo: [NSLocalizedDescriptionKey: errorStr]))
+                    Unmanaged<StreamContext>.fromOpaque(callbackData).release()
+                    return
+                }
+
+                if isFinal {
+                    let endTime = Date()
+                    let totalTime = endTime.timeIntervalSince(ctx.startTime)
+
+                    let cleaned = ctx.parent.stripControlTokens(ctx.rawResponse)
+                    var finalCleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !ctx.userMessage.isEmpty && finalCleaned.hasPrefix(ctx.userMessage) {
+                        finalCleaned = String(finalCleaned.dropFirst(ctx.userMessage.count))
+                            .trimmingCharacters(in: .whitespacesAndNewlines)
+                    }
+
+                    if finalCleaned.count > ctx.lastEmittedLength {
+                        let startIdx = finalCleaned.index(finalCleaned.startIndex, offsetBy: ctx.lastEmittedLength)
+                        let remaining = String(finalCleaned[startIdx...])
+                        ctx.onToken(remaining, false)
+                    }
+                    ctx.fullResponse = finalCleaned
+
+                    var completionTokens = Double(ctx.tokenCount)
+                    var tokensPerSecond = 0.0
+                    var ttft = 0.0
+                    if let benchInfo = litert_lm_conversation_get_benchmark_info(ctx.parent.conversation) {
+                        let numDecodeTurns = litert_lm_benchmark_info_get_num_decode_turns(benchInfo)
+                        if numDecodeTurns > 0 {
+                            let lastIdx = numDecodeTurns - 1
+                            tokensPerSecond = litert_lm_benchmark_info_get_decode_tokens_per_sec_at(benchInfo, lastIdx)
+                            completionTokens = Double(litert_lm_benchmark_info_get_decode_token_count_at(benchInfo, lastIdx))
+                        }
+                        ttft = litert_lm_benchmark_info_get_time_to_first_token(benchInfo)
+                        litert_lm_benchmark_info_delete(benchInfo)
+                    }
+
+                    let promptTokens = Double(ctx.userMessage.count) / 4.0
+                    if completionTokens == 0.0 {
+                        completionTokens = Double(ctx.fullResponse.count) / 4.0
+                    }
+                    ctx.parent.lastStats = GenerationStats(
+                        promptTokens: promptTokens,
+                        completionTokens: completionTokens,
+                        totalTokens: promptTokens + completionTokens,
+                        timeToFirstToken: ttft,
+                        totalTime: totalTime,
+                        tokensPerSecond: tokensPerSecond > 0.0 ? tokensPerSecond : (completionTokens / totalTime)
+                    )
+                    ctx.parent.history.append(Message(role: .user, content: historyUserContent))
+                    ctx.parent.history.append(Message(role: .model, content: ctx.fullResponse))
+                    ctx.onToken("", true)
+                    ctx.promise.resolve()
+                    Unmanaged<StreamContext>.fromOpaque(callbackData).release()
+                    return
+                }
+
+                if let chunk = chunk {
+                    let token = String(cString: chunk)
+                    let raw: String
+                    if token.hasPrefix("{") && token.contains("\"role\"") {
+                        raw = ctx.parent.extractTextFromResponse(token)
+                    } else {
+                        raw = token
+                    }
+
+                    ctx.rawResponse += raw
+                    let cleaned = ctx.parent.stripControlTokens(ctx.rawResponse)
+                        .trimmingLeadingCharacters(in: .whitespacesAndNewlines)
+
+                    var processed = cleaned
+                    if !ctx.userMessage.isEmpty && processed.hasPrefix(ctx.userMessage) {
+                        processed = String(processed.dropFirst(ctx.userMessage.count))
+                            .trimmingLeadingCharacters(in: .whitespacesAndNewlines)
+                    }
+
+                    let safeLen = ctx.parent.safeEmitLength(processed)
+                    if safeLen > ctx.lastEmittedLength {
+                        let chars = Array(processed)
+                        let newText = String(chars[ctx.lastEmittedLength..<safeLen])
+                        ctx.lastEmittedLength = safeLen
+                        ctx.tokenCount += 1
+                        ctx.onToken(newText, false)
+                    }
+                }
+            }
+
+            let status = litert_lm_conversation_send_message_stream(
+                conversation,
+                msgJson,
+                nil,
+                nil,
+                callback,
+                callbackData
+            )
+            if status != 0 {
+                Unmanaged<StreamContext>.fromOpaque(callbackData).release()
+                promise.reject(withError: NSError(domain: "LiteRTLM", code: Int(status), userInfo: [NSLocalizedDescriptionKey: "Failed to start streaming conversation."]))
+            }
+        }
+
+        return promise
+    }
+
     public func sendMessageWithAudio(message: String, audioPath: String) throws -> Promise<String> {
         let promise = Promise<String>()
         

--- a/ios/Tests/HybridLiteRTLMTests.swift
+++ b/ios/Tests/HybridLiteRTLMTests.swift
@@ -53,6 +53,52 @@ class HybridLiteRTLMTests: XCTestCase {
         }
     }
 
+    func testSendMessageWithImageAsyncRejectsWithoutModel() async throws {
+        do {
+            let promise = try bridge.sendMessageWithImageAsync(message: "hello", imagePath: "/tmp/image.jpg") { _, _ in }
+            _ = try await promise.await()
+            XCTFail("Should have failed without model")
+        } catch {
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, "LiteRTLM")
+            XCTAssertEqual(nsError.code, 400)
+        }
+    }
+
+    func testSendMessageWithAudioAsyncRejectsWithoutModel() async throws {
+        do {
+            let promise = try bridge.sendMessageWithAudioAsync(message: "hello", audioPath: "/tmp/audio.wav") { _, _ in }
+            _ = try await promise.await()
+            XCTFail("Should have failed without model")
+        } catch {
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, "LiteRTLM")
+            XCTAssertEqual(nsError.code, 400)
+        }
+    }
+
+    func testSendMessageWithImageAsyncRejectsFileNotFound() async throws {
+        do {
+            let promise = try bridge.sendMessageWithImageAsync(message: "hello", imagePath: "/nonexistent/image.jpg") { _, _ in }
+            _ = try await promise.await()
+            XCTFail("Should have failed without model")
+        } catch {
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, "LiteRTLM")
+        }
+    }
+
+    func testSendMessageWithAudioAsyncRejectsFileNotFound() async throws {
+        do {
+            let promise = try bridge.sendMessageWithAudioAsync(message: "hello", audioPath: "/nonexistent/audio.wav") { _, _ in }
+            _ = try await promise.await()
+            XCTFail("Should have failed without model")
+        } catch {
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, "LiteRTLM")
+        }
+    }
+
     func testInitialStats() {
         XCTAssertNoThrow(try bridge.getStats())
         if let stats = try? bridge.getStats() {

--- a/src/__mocks__/react-native-nitro-modules.ts
+++ b/src/__mocks__/react-native-nitro-modules.ts
@@ -15,6 +15,16 @@ export const mockLiteRTLM = {
     onToken("token", true);
     return Promise.resolve();
   }),
+  sendMessageWithImageAsync: jest.fn((msg, imagePath, onToken) => {
+    onToken("Mock vision ", false);
+    onToken("token", true);
+    return Promise.resolve();
+  }),
+  sendMessageWithAudioAsync: jest.fn((msg, audioPath, onToken) => {
+    onToken("Mock audio ", false);
+    onToken("token", true);
+    return Promise.resolve();
+  }),
   getHistory: jest.fn(() => []),
   resetConversation: jest.fn(),
   getStats: jest.fn(() => ({

--- a/src/__tests__/modelFactory.test.ts
+++ b/src/__tests__/modelFactory.test.ts
@@ -56,6 +56,34 @@ describe('modelFactory Security & Proxy Unit Tests', () => {
     expect(mockLiteRTLM.getMemoryUsage).toHaveBeenCalled();
   });
 
+  it('should successfully proxy sendMessageWithImageAsync and record memory metrics when done', async () => {
+    const onToken = jest.fn();
+    await llm.sendMessageWithImageAsync("Vision prompt", "/path/to/image.jpg", onToken);
+
+    expect(onToken).toHaveBeenCalledWith("Mock vision ", false);
+    expect(onToken).toHaveBeenCalledWith("token", true);
+    expect(mockLiteRTLM.sendMessageWithImageAsync).toHaveBeenCalledWith(
+      "Vision prompt",
+      "/path/to/image.jpg",
+      expect.any(Function)
+    );
+    expect(mockLiteRTLM.getMemoryUsage).toHaveBeenCalled();
+  });
+
+  it('should successfully proxy sendMessageWithAudioAsync and record memory metrics when done', async () => {
+    const onToken = jest.fn();
+    await llm.sendMessageWithAudioAsync("Audio prompt", "/path/to/audio.wav", onToken);
+
+    expect(onToken).toHaveBeenCalledWith("Mock audio ", false);
+    expect(onToken).toHaveBeenCalledWith("token", true);
+    expect(mockLiteRTLM.sendMessageWithAudioAsync).toHaveBeenCalledWith(
+      "Audio prompt",
+      "/path/to/audio.wav",
+      expect.any(Function)
+    );
+    expect(mockLiteRTLM.getMemoryUsage).toHaveBeenCalled();
+  });
+
   it('should successfully access memoryTracker and getSnapshots when memory tracking is enabled', () => {
     expect(llm.memoryTracker).toBeDefined();
     expect(llm.memoryTracker?.getCapacity()).toBe(256);

--- a/src/modelFactory.ts
+++ b/src/modelFactory.ts
@@ -132,6 +132,28 @@ export function createLLM(options?: {
         };
       }
 
+      if (prop === "sendMessageWithImageAsync") {
+        return (message: string, imagePath: string, onToken: (token: string, done: boolean) => void) => {
+          return original.call(target, message, imagePath, (token: string, done: boolean) => {
+            onToken(token, done);
+            if (done) {
+              recordMemorySnapshot();
+            }
+          });
+        };
+      }
+
+      if (prop === "sendMessageWithAudioAsync") {
+        return (message: string, audioPath: string, onToken: (token: string, done: boolean) => void) => {
+          return original.call(target, message, audioPath, (token: string, done: boolean) => {
+            onToken(token, done);
+            if (done) {
+              recordMemorySnapshot();
+            }
+          });
+        };
+      }
+
       if (SNAPSHOT_TRIGGERS.has(prop as string)) {
         return async (...args: any[]) => {
           const result = await original.apply(target, args);

--- a/src/specs/LiteRTLM.nitro.ts
+++ b/src/specs/LiteRTLM.nitro.ts
@@ -227,6 +227,19 @@ export interface LiteRTLM extends HybridObject<{
   sendMessageWithImage(message: string, imagePath: string): Promise<string>;
 
   /**
+   * Send a text message with an image and get a streaming response.
+   * Tokens are delivered via callback as they are generated.
+   * @param message User message text.
+   * @param imagePath Absolute path to an image file.
+   * @param onToken Callback invoked for each token (token, isDone).
+   */
+  sendMessageWithImageAsync(
+    message: string,
+    imagePath: string,
+    onToken: (token: string, done: boolean) => void,
+  ): Promise<void>;
+
+  /**
    * Download a model file from a URL.
    * @param url URL to download from.
    * @param fileName Filename to save as (in app's files directory).
@@ -252,6 +265,19 @@ export interface LiteRTLM extends HybridObject<{
    * @returns The model's response text.
    */
   sendMessageWithAudio(message: string, audioPath: string): Promise<string>;
+
+  /**
+   * Send a text message with audio and get a streaming response.
+   * Tokens are delivered via callback as they are generated.
+   * @param message User message text.
+   * @param audioPath Absolute path to an audio file (WAV).
+   * @param onToken Callback invoked for each token (token, isDone).
+   */
+  sendMessageWithAudioAsync(
+    message: string,
+    audioPath: string,
+    onToken: (token: string, done: boolean) => void,
+  ): Promise<void>;
 
   /**
    * Send a unified multimodal message containing text and/or zero-copy binary buffers.


### PR DESCRIPTION
## Summary

- Extends the Nitro spec with `sendMessageWithImageAsync` and
  `sendMessageWithAudioAsync` — streaming variants of the multimodal API
  that deliver tokens incrementally via `(token: string, done: boolean)` callback
- iOS: Swift Direct-FFI implementation via `LiteRtLmStreamCallback` on the
  serial engine queue, with file existence validation and history recording
- Android: Kotlin implementation via `StreamingCallbackListener` +
  `CountDownLatch`; image variant resizes via `resizeImageIfNeeded` and
  cleans up the temp file after the latch resolves
- TS: factory proxy wraps both methods to record memory snapshots on
  stream completion

## Test plan

- [ ] Jest: proxy tests for `sendMessageWithImageAsync` / `sendMessageWithAudioAsync` pass (`npm test`)
- [ ] XCTest: no-model and file-not-found rejection tests pass on iOS simulator
- [ ] Robolectric: no-model rejection tests pass (`./gradlew test`)
- [ ] Manual: streaming image/audio inference delivers incremental tokens on a loaded model (iOS + Android)