### PR TITLE
fix(ts): multimodal and advanced options not working via useModel hook (with requested changes)

### DIFF
--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -150,4 +150,106 @@ describe('useModel React Hook Unit Tests', () => {
     hookResult.unmount();
     expect(mockLiteRTLM.close).toHaveBeenCalled();
   });
+
+  describe('nativeConfig field forwarding', () => {
+    async function loadWithConfig(config: any) {
+      let hookResult: any;
+      await TestRenderer.act(async () => {
+        hookResult = renderHook(() => useModel('https://example.com/model.litertlm', config));
+      });
+      // loadModel is called as: loadModel(pathOrUrl, nativeConfig, onProgress)
+      const [, nativeConfig] = mockLiteRTLM.loadModel.mock.calls[0];
+      return nativeConfig;
+    }
+
+    it('should forward validate to nativeConfig', async () => {
+      const nativeConfig = await loadWithConfig({ autoLoad: true, validate: true });
+      expect(nativeConfig).toHaveProperty('validate', true);
+    });
+
+    it('should forward multimodal to nativeConfig', async () => {
+      const nativeConfig = await loadWithConfig({ autoLoad: true, multimodal: true });
+      expect(nativeConfig).toHaveProperty('multimodal', true);
+    });
+
+    it('should forward enableSpeculativeDecoding to nativeConfig', async () => {
+      const nativeConfig = await loadWithConfig({ autoLoad: true, enableSpeculativeDecoding: true });
+      expect(nativeConfig).toHaveProperty('enableSpeculativeDecoding', true);
+    });
+
+    it('should forward tools array to nativeConfig', async () => {
+      const tools = [{ name: 'get_weather', description: 'Gets weather', parametersJson: '{}' }];
+      const nativeConfig = await loadWithConfig({ autoLoad: true, tools });
+      expect(nativeConfig).toHaveProperty('tools');
+      expect(nativeConfig.tools).toEqual(tools);
+    });
+
+    it('should omit validate from nativeConfig when not provided', async () => {
+      const nativeConfig = await loadWithConfig({ autoLoad: true });
+      expect(nativeConfig).not.toHaveProperty('validate');
+    });
+
+    it('should omit multimodal from nativeConfig when not provided', async () => {
+      const nativeConfig = await loadWithConfig({ autoLoad: true });
+      expect(nativeConfig).not.toHaveProperty('multimodal');
+    });
+
+    it('should omit enableSpeculativeDecoding from nativeConfig when not provided', async () => {
+      const nativeConfig = await loadWithConfig({ autoLoad: true });
+      expect(nativeConfig).not.toHaveProperty('enableSpeculativeDecoding');
+    });
+
+    it('should omit tools from nativeConfig when not provided', async () => {
+      const nativeConfig = await loadWithConfig({ autoLoad: true });
+      expect(nativeConfig).not.toHaveProperty('tools');
+    });
+
+    it('should not reload the model when tools array is a new reference with the same content (toolsKey stability)', async () => {
+      const tools = [{ name: 'get_weather', description: 'Gets weather', parametersJson: '{}' }];
+      let hookResult: any;
+
+      await TestRenderer.act(async () => {
+        hookResult = renderHook(
+          (props: any) => useModel('https://example.com/model.litertlm', props),
+          { autoLoad: true, tools },
+        );
+      });
+
+      const callCountAfterMount = mockLiteRTLM.loadModel.mock.calls.length;
+
+      // Re-render with a new array reference that has identical content
+      await TestRenderer.act(async () => {
+        hookResult.rerender({
+          autoLoad: true,
+          tools: [{ name: 'get_weather', description: 'Gets weather', parametersJson: '{}' }],
+        });
+      });
+
+      expect(mockLiteRTLM.loadModel.mock.calls.length).toBe(callCountAfterMount);
+    });
+
+    it('should reload the model when tools content actually changes', async () => {
+      const tools = [{ name: 'get_weather', description: 'Gets weather', parametersJson: '{}' }];
+      let hookResult: any;
+
+      await TestRenderer.act(async () => {
+        hookResult = renderHook(
+          (props: any) => useModel('https://example.com/model.litertlm', props),
+          { autoLoad: true, tools },
+        );
+      });
+
+      const callCountAfterMount = mockLiteRTLM.loadModel.mock.calls.length;
+
+      // Re-render with different tools content
+      await TestRenderer.act(async () => {
+        hookResult.rerender({
+          autoLoad: true,
+          tools: [{ name: 'search', description: 'Searches the web', parametersJson: '{}' }],
+        });
+      });
+
+      expect(mockLiteRTLM.loadModel.mock.calls.length).toBeGreaterThan(callCountAfterMount);
+    });
+  });
 });

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -78,6 +78,10 @@ export function useModel(
   const temperature = config?.temperature;
   const topK = config?.topK;
   const topP = config?.topP;
+  const validate = config?.validate;
+  const multimodal = config?.multimodal;
+  const tools = config?.tools;
+  const enableSpeculativeDecoding = config?.enableSpeculativeDecoding;
 
   // Build a stable config object from the destructured primitives
   const nativeConfig = useMemo<LLMConfig>(
@@ -88,8 +92,14 @@ export function useModel(
       ...(temperature !== undefined && { temperature }),
       ...(topK !== undefined && { topK }),
       ...(topP !== undefined && { topP }),
+       ...(validate !== undefined && { validate }),
+      ...(multimodal !== undefined && { multimodal }),
+      ...(tools !== undefined && { tools }),
+      ...(enableSpeculativeDecoding !== undefined && {
+        enableSpeculativeDecoding,
+      }),
     }),
-    [backend, systemPrompt, maxTokens, temperature, topK, topP],
+    [backend, systemPrompt, maxTokens, temperature, topK, topP, validate, multimodal, tools, enableSpeculativeDecoding],
   );
 
   /**

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -81,6 +81,7 @@ export function useModel(
   const validate = config?.validate;
   const multimodal = config?.multimodal;
   const tools = config?.tools;
+  const toolsKey = JSON.stringify(tools); // stable primitive for deps — avoids infinite re-renders from non-primitive array references
   const enableSpeculativeDecoding = config?.enableSpeculativeDecoding;
 
   // Build a stable config object from the destructured primitives
@@ -99,7 +100,7 @@ export function useModel(
         enableSpeculativeDecoding,
       }),
     }),
-    [backend, systemPrompt, maxTokens, temperature, topK, topP, validate, multimodal, tools, enableSpeculativeDecoding],
+    [backend, systemPrompt, maxTokens, temperature, topK, topP, validate, multimodal, enableSpeculativeDecoding, toolsKey],
   );
 
   /**

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -177,15 +177,13 @@ export function useModel(
           let fullResponse = "";
           try {
             modelRef.current?.sendMessageAsync(
-              prompt,
-              (token: string, done: boolean) => {
+              prompt, (token: string, done: boolean) => {
                 fullResponse += token;
                 if (done) {
                   refreshMemorySummary();
                   resolve(fullResponse);
                 }
-              },
-            ).catch(reject);
+              }).catch(reject);
           } catch (e: any) {
             reject(e);
           }


### PR DESCRIPTION
@hung-yueh @wh1tecat-nya 
so sorry to create an additional pull request, I do not believe I have the correct permissions to add directly to the existing PR.

this pull request is referrential to the changes requested by @hung-yueh on #12 
it is designed to fix the problem wherein multimodal and other advanced features do not function correctly when invoked through `useModel`. as @wh1tecat-nya identified, the fields were destructured from config but never were forwarded to the `nativeConfig` memo or its dependency array. 

When running on iOS, this produces the error mesage:

> Multimodal not supported: multimodal (image/audio) is not available on iOS. The XCFramework lacks compiled vision and audio executor ops.

I reimplemented the changes wh1tecat had added on a branch rebased from the current main, re-bringing over the missing fields starting on line 81 and placing them in the useMemo, which now begins on line 88.
I also used JSON stringify as opposed to the tools array directly, to prevent infinite reload. See line 84 for this definition.
Finally, I added some tests to hooks.test.ts to test that these fields indeed reach native. I also added tests against the infinite re-render.

Again, so sorry for the duplicate, was just hoping to get this working soon because I am relying on it for a research project of mine (: 
Let me know if there are any further changes needed, and thank you both for tracking down the initial issue here!