### PR TITLE
feat: decouple model management & unify multimodal execute pipeline

### DIFF
--- a/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
+++ b/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
@@ -83,6 +83,9 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
     @Volatile
     private var isClosed = false
 
+    private val modelStore = HybridModelStore()
+    private var loadedModelPath: String? = null
+
     // Conversation history for getHistory()
     // Synchronized to prevent ConcurrentModificationException: history is
     // written from Promise.parallel workers and sendMessageAsync SDK callbacks,
@@ -291,6 +294,7 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
                     // Create Conversation
                     createNewConversation()
                     Log.i(TAG, "Conversation created successfully")
+                    loadedModelPath = modelPath
     
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to load model: ${e.message}", e)
@@ -343,7 +347,7 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
         // Save to temp file
         val cacheDir = LiteRTLMInitProvider.applicationContext?.cacheDir
             ?: throw RuntimeException("Application context not available for image resizing")
-        val tempFile = java.io.File(cacheDir, "resized_${System.currentTimeMillis()}.jpg")
+        val tempFile = java.io.File(cacheDir, "resized_${java.util.UUID.randomUUID()}.jpg")
         java.io.FileOutputStream(tempFile).use { out ->
             resizedBitmap.compress(android.graphics.Bitmap.CompressFormat.JPEG, 90, out)
         }
@@ -366,16 +370,17 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
         )
 
     override fun downloadModel(url: String, fileName: String, onProgress: ((Double) -> Unit)?): Promise<String> {
-        val store = HybridModelStore()
-        return store.downloadFile(url, fileName, "", onProgress ?: {})
+        return modelStore.downloadFile(url, fileName, "{}", onProgress ?: {})
     }
 
     override fun deleteModel(fileName: String): Promise<Unit> {
         return Promise.parallel {
-            val store = HybridModelStore()
-            store.deleteFile(fileName)
-            if (engine != null) {
-                cleanupInternal()
+            modelStore.deleteFile(fileName)
+            val currentlyLoadedName = loadedModelPath?.substringAfterLast("/")?.lowercase()
+            if (currentlyLoadedName != null && currentlyLoadedName == fileName.lowercase()) {
+                if (engine != null) {
+                    cleanupInternal()
+                }
             }
         }
     }
@@ -477,6 +482,7 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
             conversation = null
             engine?.close()        // Direct call
             engine = null 
+            loadedModelPath = null
         } catch (e: Exception) {
             Log.e(TAG, "Error closing resources", e)
         }
@@ -549,9 +555,13 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
         onToken: (String, Boolean) -> Unit,
     ): Promise<Unit> {
         val voidPromise = Promise<Unit>()
-        execute(parts, onToken)
-            .then { voidPromise.resolve(Unit) }
-            .catch { voidPromise.reject(it) }
+        try {
+            execute(parts, onToken)
+                .then { voidPromise.resolve(Unit) }
+                .catch { voidPromise.reject(it) }
+        } catch (e: Throwable) {
+            voidPromise.reject(e)
+        }
         return voidPromise
     }
 
@@ -609,7 +619,7 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
                                 part.bytes != null -> {
                                     val tmp = java.io.File(
                                         LiteRTLMInitProvider.applicationContext!!.cacheDir,
-                                        "litert_buf_${System.currentTimeMillis()}.jpg"
+                                        "litert_buf_${java.util.UUID.randomUUID()}.jpg"
                                     )
                                     tmp.writeBytes(part.bytes)
                                     tempFiles.add(tmp)
@@ -630,7 +640,7 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
                                 part.bytes != null -> {
                                     val tmp = java.io.File(
                                         LiteRTLMInitProvider.applicationContext!!.cacheDir,
-                                        "litert_buf_${System.currentTimeMillis()}.wav"
+                                        "litert_buf_${java.util.UUID.randomUUID()}.wav"
                                     )
                                     tmp.writeBytes(part.bytes)
                                     tempFiles.add(tmp)

--- a/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
+++ b/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
@@ -41,71 +41,7 @@ import java.util.concurrent.atomic.AtomicReference
 // Alias to avoid confusion
 typealias LiteRTMessage = com.google.ai.edge.litertlm.Message
 
-/**
- * Named implementation of the LiteRT-LM MessageCallback for streaming inference.
- *
- * Extracted from the anonymous inline class in sendMessageAsync for testability.
- * Accumulates response chunks, forwards tokens to JS, and appends the final
- * response to the conversation history.
- */
-internal class StreamingCallbackListener(
-    private val onToken: (String, Boolean) -> Unit,
-    private val responseBuilder: StringBuilder,
-    private val history: MutableList<Message>,
-    private val userMessage: String,
-    private val onStatsReady: (GenerationStats) -> Unit,
-) : com.google.ai.edge.litertlm.MessageCallback {
 
-    private val startTime = System.nanoTime()
-    private var firstTokenTime = 0L
-    private var tokenCount = 0
-
-    override fun onMessage(message: com.google.ai.edge.litertlm.Message) {
-        val chunk = message.contents.contents
-            .filterIsInstance<com.google.ai.edge.litertlm.Content.Text>()
-            .joinToString("") { it.text }
-
-        if (firstTokenTime == 0L && chunk.isNotEmpty()) {
-            firstTokenTime = System.nanoTime()
-        }
-        if (chunk.isNotEmpty()) {
-            tokenCount++
-        }
-
-        onToken(chunk, false)
-
-        if (chunk.isNotEmpty()) {
-            responseBuilder.append(chunk)
-        }
-    }
-
-    override fun onDone() {
-        onToken("", true)
-        val fullResponse = responseBuilder.toString()
-        history.add(Message(Role.MODEL, fullResponse))
-
-        // Compute stats using heuristic token counts (~4 chars/token)
-        val elapsedMs = (System.nanoTime() - startTime) / 1_000_000.0
-        val ttftMs = if (firstTokenTime > 0) (firstTokenTime - startTime) / 1_000_000.0 else 0.0
-        val promptTokens = userMessage.length / 4.0
-        val completionTokens = fullResponse.length / 4.0
-        onStatsReady(GenerationStats(
-            promptTokens = promptTokens,
-            completionTokens = completionTokens,
-            totalTokens = promptTokens + completionTokens,
-            timeToFirstToken = ttftMs,
-            totalTime = elapsedMs,
-            tokensPerSecond = if (elapsedMs > 0) completionTokens / (elapsedMs / 1000.0) else 0.0
-        ))
-
-        Log.d("StreamingCallbackListener", "Streaming done. Length: ${fullResponse.length}, TTFT: ${ttftMs.toLong()}ms, Total: ${elapsedMs.toLong()}ms")
-    }
-
-    override fun onError(throwable: Throwable) {
-        Log.e("StreamingCallbackListener", "Async generation failed", throwable)
-        onToken("Error: ${throwable.message}", true)
-    }
-}
 
 /**
  * Kotlin implementation of LiteRTLM using the LiteRT-LM Android SDK.
@@ -169,7 +105,7 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
     private var temperature: Double = 0.7
     private var topK: Int = 40
     private var topP: Double = 0.95
-    private var maxTokens: Int = 1024
+    private var maxTokens: Int = 2048
     private var systemPrompt: String? = null
     private var tools: Array<ToolDefinition>? = null
     private var enableSpeculativeDecoding: Boolean = false
@@ -322,102 +258,12 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
         }
     }
 
-    // -------------------------------------------------------------------------
-    // sendMessage - Helper for one-shot generation (internally uses Async)
-    // -------------------------------------------------------------------------
-    override fun sendMessage(message: String): Promise<String> {
-        // Implement Promise-based sendMessage using suspend coroutine logic wrapped in Promise
-        // Since Promise.parallel expects a blocking block returning T, 
-        // and sendMessageAsync is callback-based, we need to bridge them.
-        // HOWEVER, we can just use the synchronous `sendMessage` API of the SDK 
-        // inside the `Promise.parallel` block, which moves it off the main thread!
-        return Promise.parallel {
-            ensureLoaded()
+    // Legacy inference — shapes mirror src/inferenceRouting.ts; JS createLLM routes via execute.
+    override fun sendMessage(message: String): Promise<String> =
+        execute(parts = arrayOf(MultimodalPartFactories.textPart(message)), onToken = null)
 
-            // Add user message to history
-            history.add(Message(Role.USER, message))
-            Log.i(TAG, "sendMessage (Promise): $message")
-            
-            // Blocking inference (safe here because we are in Promise.parallel worker thread)
-            val userMsg = LiteRTMessage.user(message)
-            val startTime = System.nanoTime()
-            val responseMsg = conversation!!.sendMessage(message = userMsg)
-            val elapsedMs = (System.nanoTime() - startTime) / 1_000_000.0
-            
-            // Extract text
-            val response = responseMsg.contents.contents
-                .filterIsInstance<com.google.ai.edge.litertlm.Content.Text>()
-                .joinToString("") { it.text } 
-            
-            // Add model response to history
-            history.add(Message(Role.MODEL, response))
-            
-            // Update stats with real timing data
-            // Token count heuristic: LiteRT-LM Android SDK does not expose
-            // actual token counts from inference. We approximate using
-            // ~4 chars/token. iOS uses the C API benchmark info for real counts.
-            val promptTokens = message.length / 4.0
-            val completionTokens = response.length / 4.0
-            lastStats = GenerationStats(
-                promptTokens = promptTokens,
-                completionTokens = completionTokens,
-                totalTokens = promptTokens + completionTokens,
-                timeToFirstToken = 0.0, // Not available from sync API
-                totalTime = elapsedMs,
-                tokensPerSecond = if (elapsedMs > 0) completionTokens / (elapsedMs / 1000.0) else 0.0
-            )
-            
-            response // Return the string
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // sendMessageAsync - Streaming inference
-    // -------------------------------------------------------------------------
-    override fun sendMessageAsync(message: String, onToken: (String, Boolean) -> Unit): Promise<Unit> {
-        return Promise.parallel {
-            val latch = CountDownLatch(1)
-            val errorRef = AtomicReference<Throwable?>(null)
-
-            ensureLoaded()
-
-            // Add user message to history
-            history.add(Message(Role.USER, message))
-            Log.d(TAG, "sendMessageAsync: $message")
-
-            val fullResponseBuilder = StringBuilder()
-            
-            val listener = StreamingCallbackListener(
-                onToken = { token, done ->
-                    onToken(token, done)
-                    if (done) {
-                        latch.countDown()
-                    }
-                },
-                responseBuilder = fullResponseBuilder,
-                history = history,
-                userMessage = message,
-                onStatsReady = { stats -> lastStats = stats },
-            )
-
-            try {
-                val userMsg = LiteRTMessage.user(message)
-                conversation!!.sendMessageAsync(message = userMsg, callback = listener)
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to initiate async generation", e)
-                errorRef.set(e)
-                onToken("Error: ${e.message}", true)
-                latch.countDown()
-            }
-
-            // Wait for completion or error
-            latch.await()
-            val err = errorRef.get()
-            if (err != null) {
-                throw RuntimeException("Async inference failed: ${err.message}", err)
-            }
-        }
-    }
+    override fun sendMessageAsync(message: String, onToken: (String, Boolean) -> Unit): Promise<Unit> =
+        executeVoid(parts = arrayOf(MultimodalPartFactories.textPart(message)), onToken = onToken)
 
     // -------------------------------------------------------------------------
     // Multimodal methods
@@ -463,112 +309,17 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
         return tempFile.absolutePath
     }
 
-    override fun sendMessageWithImage(message: String, imagePath: String): Promise<String> {
-        return Promise.parallel {
-            ensureLoaded()
-            Log.i(TAG, "sendMessageWithImage: $message, path=$imagePath")
+    override fun sendMessageWithImage(message: String, imagePath: String): Promise<String> =
+        execute(
+            parts = arrayOf(MultimodalPartFactories.textPart(message), MultimodalPartFactories.imagePart(imagePath)),
+            onToken = null,
+        )
 
-            // Resize image to prevent OOM on high-resolution photos
-            val processedImagePath = resizeImageIfNeeded(imagePath)
-
-            // Create multimodal message
-            // Use factory method Message.of passing a list of Content
-            val textContent = Content.Text(message)
-            
-            val userMsg = LiteRTMessage.user(Contents.of(textContent, Content.ImageFile(processedImagePath)))
-
-            // Add to history
-            history.add(Message(Role.USER, "$message [Image]"))
-
-            val responseMsg = conversation!!.sendMessage(message = userMsg)
-            
-            val response = responseMsg.contents.contents
-                .filterIsInstance<Content.Text>()
-                .joinToString("") { it.text }
-
-            history.add(Message(Role.MODEL, response))
-
-            // Clean up temp resized image to prevent cache dir bloat
-            if (processedImagePath != imagePath) {
-                try {
-                    java.io.File(processedImagePath).delete()
-                } catch (e: Exception) {
-                    Log.w(TAG, "Failed to clean up temp image: ${e.message}")
-                }
-            }
-            
-            response
-        }
-    }
-
-    override fun sendMessageWithImageAsync(message: String, imagePath: String, onToken: (String, Boolean) -> Unit): Promise<Unit> {
-        return Promise.parallel {
-            val latch = CountDownLatch(1)
-            val errorRef = AtomicReference<Throwable?>(null)
-
-            ensureLoaded()
-
-            Log.i(TAG, "sendMessageWithImageAsync: $message, path=$imagePath")
-
-            // Resize image to prevent OOM on high-resolution photos
-            val processedImagePath = resizeImageIfNeeded(imagePath)
-
-            val fullResponseBuilder = StringBuilder()
-            
-            val listener = StreamingCallbackListener(
-                onToken = { token, done ->
-                    onToken(token, done)
-                    if (done) {
-                        latch.countDown()
-                    }
-                },
-                responseBuilder = fullResponseBuilder,
-                history = history,
-                userMessage = message,
-                onStatsReady = { stats -> lastStats = stats },
-            )
-
-            try {
-                val textContent = Content.Text(message)
-                val userMsg = LiteRTMessage.user(Contents.of(textContent, Content.ImageFile(processedImagePath)))
-
-                history.add(Message(Role.USER, "$message [Image]"))
-
-                conversation!!.sendMessageAsync(message = userMsg, callback = listener)
-            } catch (e: Exception) {
-                // Clean up temp resized image to prevent cache dir bloat
-                if (processedImagePath != imagePath) {
-                    try {
-                        java.io.File(processedImagePath).delete()
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Failed to clean up temp image: ${e.message}")
-                    }
-                }
-
-                Log.e(TAG, "Failed to initiate async multimodal generation", e)
-                errorRef.set(e)
-                onToken("Error: ${e.message}", true)
-                latch.countDown()
-            }
-
-            // Wait for completion or error
-            latch.await()
-
-            // Clean up temp resized image to prevent cache dir bloat
-            if (processedImagePath != imagePath) {
-                try {
-                    java.io.File(processedImagePath).delete()
-                } catch (e: Exception) {
-                    Log.w(TAG, "Failed to clean up temp image: ${e.message}")
-                }
-            }
-
-            val err = errorRef.get()
-            if (err != null) {
-                throw RuntimeException("Async multimodal inference failed: ${err.message}", err)
-            }
-        }
-    }
+    override fun sendMessageWithImageAsync(message: String, imagePath: String, onToken: (String, Boolean) -> Unit): Promise<Unit> =
+        executeVoid(
+            parts = arrayOf(MultimodalPartFactories.textPart(message), MultimodalPartFactories.imagePart(imagePath)),
+            onToken = onToken,
+        )
 
     override fun downloadModel(url: String, fileName: String, onProgress: ((Double) -> Unit)?): Promise<String> {
         val store = HybridModelStore()
@@ -585,79 +336,17 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
         }
     }
 
-    override fun sendMessageWithAudioAsync(message: String, audioPath: String, onToken: (String, Boolean) -> Unit): Promise<Unit> {
-        return Promise.parallel {
-            val latch = CountDownLatch(1)
-            val errorRef = AtomicReference<Throwable?>(null)
+    override fun sendMessageWithAudioAsync(message: String, audioPath: String, onToken: (String, Boolean) -> Unit): Promise<Unit> =
+        executeVoid(
+            parts = arrayOf(MultimodalPartFactories.textPart(message), MultimodalPartFactories.audioPart(audioPath)),
+            onToken = onToken,
+        )
 
-            ensureLoaded()
-
-            Log.i(TAG, "sendMessageWithAudioAsync: $message, path=$audioPath")
-
-            val fullResponseBuilder = StringBuilder()
-
-            val listener = StreamingCallbackListener(
-                onToken = { token, done ->
-                    onToken(token, done)
-                    if (done) {
-                        latch.countDown()
-                    }
-                },
-                responseBuilder = fullResponseBuilder,
-                history = history,
-                userMessage = message,
-                onStatsReady = { stats -> lastStats = stats },
-            )
-
-            try {
-                val userMsg = LiteRTMessage.user(Contents.of(
-                    Content.Text(message),
-                    Content.AudioFile(audioPath)
-                ))
-
-                history.add(Message(Role.USER, "$message [Audio]"))
-
-                conversation!!.sendMessageAsync(message = userMsg, callback = listener)
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to initiate async audio generation", e)
-                errorRef.set(e)
-                onToken("Error: ${e.message}", true)
-                latch.countDown()
-            }
-
-            latch.await()
-            val err = errorRef.get()
-            if (err != null) {
-                throw RuntimeException("Async audio inference failed: ${err.message}", err)
-            }
-        }
-    }
-
-    override fun sendMessageWithAudio(message: String, audioPath: String): Promise<String> {
-        return Promise.parallel {
-            ensureLoaded()
-            Log.i(TAG, "sendMessageWithAudio: $message, path=$audioPath")
-
-            // Load audio
-            
-            val userMsg = LiteRTMessage.user(Contents.of(
-                Content.Text(message),
-                Content.AudioFile(audioPath)
-            ))
-
-            history.add(Message(Role.USER, "$message [Audio]"))
-            
-            val responseMsg = conversation!!.sendMessage(message = userMsg)
-            
-            val response = responseMsg.contents.contents
-                .filterIsInstance<Content.Text>()
-                .joinToString("") { it.text }
-                
-            history.add(Message(Role.MODEL, response))
-            
-            response
-        }
-    }
+    override fun sendMessageWithAudio(message: String, audioPath: String): Promise<String> =
+        execute(
+            parts = arrayOf(MultimodalPartFactories.textPart(message), MultimodalPartFactories.audioPart(audioPath)),
+            onToken = null,
+        )
 
     // -------------------------------------------------------------------------
     // Helpers
@@ -866,57 +555,180 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
     }
 
     override fun sendMultimodalMessage(parts: Array<MultimodalPart>): Promise<String> {
+        return execute(parts = parts, onToken = null)
+    }
+
+    /** Streaming adapter for legacy `Promise<Unit>` APIs — all inference runs through [execute]. */
+    private fun executeVoid(
+        parts: Array<MultimodalPart>,
+        onToken: (String, Boolean) -> Unit,
+    ): Promise<Unit> {
+        val voidPromise = Promise<Unit>()
+        execute(parts, onToken)
+            .then { voidPromise.resolve(Unit) }
+            .catch { voidPromise.reject(it) }
+        return voidPromise
+    }
+
+    private class PreprocessedPart(
+        val type: PartType,
+        val text: String?,
+        val path: String?,
+        val bytes: ByteArray?
+    )
+
+    override fun execute(parts: Array<MultimodalPart>, onToken: ((token: String, done: Boolean) -> Unit)?): Promise<String> {
+        // Preprocess synchronously on the JS/JSI thread to safely extract JS buffer bytes
+        val preprocessed = parts.map { part ->
+            val bytes = when (part.type) {
+                PartType.IMAGE -> part.imageBuffer?.let { buf ->
+                    val javaBuf = buf.getBuffer(false)
+                    val arr = ByteArray(javaBuf.remaining())
+                    javaBuf.get(arr)
+                    arr
+                }
+                PartType.AUDIO -> part.audioBuffer?.let { buf ->
+                    val javaBuf = buf.getBuffer(false)
+                    val arr = ByteArray(javaBuf.remaining())
+                    javaBuf.get(arr)
+                    arr
+                }
+                else -> null
+            }
+            PreprocessedPart(
+                type = part.type,
+                text = part.text,
+                path = part.path,
+                bytes = bytes
+            )
+        }
+
         return Promise.parallel {
             ensureLoaded()
-            val contents = mutableListOf<Content>()
-            var userTextRepresentation = ""
-            for (part in parts) {
-                when (part.type) {
-                    PartType.TEXT -> part.text?.let { 
-                        contents.add(Content.Text(it))
-                        userTextRepresentation += "$it "
+
+            val tempFiles = mutableListOf<java.io.File>()
+
+            try {
+                val contents = mutableListOf<Content>()
+                var userTextRepresentation = ""
+
+                for (part in preprocessed) {
+                    when (part.type) {
+                        PartType.TEXT -> part.text?.let {
+                            contents.add(Content.Text(it))
+                            userTextRepresentation += "$it "
+                        }
+                        PartType.IMAGE -> {
+                            val imagePath = when {
+                                part.path != null -> part.path
+                                part.bytes != null -> {
+                                    val tmp = java.io.File(
+                                        LiteRTLMInitProvider.applicationContext!!.cacheDir,
+                                        "litert_buf_${System.currentTimeMillis()}.jpg"
+                                    )
+                                    tmp.writeBytes(part.bytes)
+                                    tempFiles.add(tmp)
+                                    tmp.absolutePath
+                                }
+                                else -> null
+                            }
+                            if (imagePath != null) {
+                                val processedPath = resizeImageIfNeeded(imagePath)
+                                if (processedPath != imagePath) tempFiles.add(java.io.File(processedPath))
+                                contents.add(Content.ImageFile(processedPath))
+                                userTextRepresentation += "[Image] "
+                            }
+                        }
+                        PartType.AUDIO -> {
+                            val audioPath = when {
+                                part.path != null -> part.path
+                                part.bytes != null -> {
+                                    val tmp = java.io.File(
+                                        LiteRTLMInitProvider.applicationContext!!.cacheDir,
+                                        "litert_buf_${System.currentTimeMillis()}.wav"
+                                    )
+                                    tmp.writeBytes(part.bytes)
+                                    tempFiles.add(tmp)
+                                    tmp.absolutePath
+                                }
+                                else -> null
+                            }
+                            if (audioPath != null) {
+                                contents.add(Content.AudioFile(audioPath))
+                                userTextRepresentation += "[Audio] "
+                            }
+                        }
                     }
-                    PartType.IMAGE -> part.imageBuffer?.let { buffer ->
-                        val byteBuffer = buffer.getBuffer(false)
-                        val bytes = ByteArray(byteBuffer.remaining())
-                        byteBuffer.get(bytes)
-                        contents.add(Content.ImageBytes(bytes))
-                        userTextRepresentation += "[Image Buffer] "
+                }
+
+                userTextRepresentation = userTextRepresentation.trim()
+                history.add(Message(Role.USER, userTextRepresentation))
+
+                val userMsg = LiteRTMessage.user(Contents.of(contents))
+
+                if (onToken != null) {
+                    // ── Streaming path ────────────────────────────────────────────────
+                    val latch = CountDownLatch(1)
+                    val errorRef = AtomicReference<Throwable?>(null)
+                    val fullResponseBuilder = StringBuilder()
+
+                    val listener = StreamingCallbackListener(
+                        onToken = { token, done ->
+                            onToken(token, done)
+                            if (done) latch.countDown()
+                        },
+                        responseBuilder = fullResponseBuilder,
+                        history = history,
+                        userMessage = userTextRepresentation,
+                        onStatsReady = { stats -> lastStats = stats },
+                        onFailure = { e -> errorRef.set(e) }
+                    )
+
+                    try {
+                        conversation!!.sendMessageAsync(message = userMsg, callback = listener)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "execute streaming failed", e)
+                        errorRef.set(e)
+                        onToken("Error: ${e.message}", true)
+                        latch.countDown()
                     }
-                    PartType.AUDIO -> part.audioBuffer?.let { buffer ->
-                        val byteBuffer = buffer.getBuffer(false)
-                        val bytes = ByteArray(byteBuffer.remaining())
-                        byteBuffer.get(bytes)
-                        contents.add(Content.AudioBytes(bytes))
-                        userTextRepresentation += "[Audio Buffer] "
+
+                    latch.await()
+                    errorRef.get()?.let { throw RuntimeException("execute streaming failed: ${it.message}", it) }
+                    fullResponseBuilder.toString()
+
+                } else {
+                    // ── Blocking path ─────────────────────────────────────────────────
+                    val startTime = System.nanoTime()
+                    val responseMsg = conversation!!.sendMessage(message = userMsg)
+                    val elapsedMs = (System.nanoTime() - startTime) / 1_000_000.0
+
+                    val response = responseMsg.contents.contents
+                        .filterIsInstance<Content.Text>()
+                        .joinToString("") { it.text }
+
+                    history.add(Message(Role.MODEL, response))
+
+                    val promptTokens = userTextRepresentation.length / 4.0
+                    val completionTokens = response.length / 4.0
+                    lastStats = GenerationStats(
+                        promptTokens = promptTokens,
+                        completionTokens = completionTokens,
+                        totalTokens = promptTokens + completionTokens,
+                        timeToFirstToken = 0.0,
+                        totalTime = elapsedMs,
+                        tokensPerSecond = if (elapsedMs > 0) completionTokens / (elapsedMs / 1000.0) else 0.0
+                    )
+                    response
+                }
+            } finally {
+                // Clean up all temp files created during this execute call
+                for (f in tempFiles) {
+                    try { f.delete() } catch (e: Exception) {
+                        Log.w(TAG, "Failed to delete temp file: ${f.absolutePath}")
                     }
                 }
             }
-            userTextRepresentation = userTextRepresentation.trim()
-            history.add(Message(Role.USER, userTextRepresentation))
-
-            val userMsg = LiteRTMessage.user(Contents.of(contents))
-            val startTime = System.nanoTime()
-            val responseMsg = conversation!!.sendMessage(message = userMsg)
-            val elapsedMs = (System.nanoTime() - startTime) / 1_000_000.0
-
-            val response = responseMsg.contents.contents
-                .filterIsInstance<Content.Text>()
-                .joinToString("") { it.text }
-
-            history.add(Message(Role.MODEL, response))
-            
-            val promptTokens = userTextRepresentation.length / 4.0
-            val completionTokens = response.length / 4.0
-            lastStats = GenerationStats(
-                promptTokens = promptTokens,
-                completionTokens = completionTokens,
-                totalTokens = promptTokens + completionTokens,
-                timeToFirstToken = 0.0,
-                totalTime = elapsedMs,
-                tokensPerSecond = if (elapsedMs > 0) completionTokens / (elapsedMs / 1000.0) else 0.0
-            )
-            response
         }
     }
 

--- a/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
+++ b/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
@@ -571,123 +571,16 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
     }
 
     override fun downloadModel(url: String, fileName: String, onProgress: ((Double) -> Unit)?): Promise<String> {
-        return Promise.parallel {
-            Log.i(TAG, "downloadModel: $url -> $fileName")
-            
-            if (!url.startsWith("https://", ignoreCase = true)) {
-                throw IllegalArgumentException("Invalid download URL: HTTPS is required for security.")
-            }
-            
-            if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
-                throw IllegalArgumentException("Invalid filename: path traversal or directory separators are not allowed.")
-            }
-            
-            val context = LiteRTLMInitProvider.applicationContext ?: throw RuntimeException("Context not available")
-            val modelsDir = java.io.File(context.filesDir, "models")
-            if (!modelsDir.exists()) {
-                modelsDir.mkdirs()
-            }
-            
-            val modelFile = java.io.File(modelsDir, fileName)
-            val tempFile = java.io.File(modelsDir, "$fileName.tmp")
-            
-            // Check if file exists and has content
-            if (modelFile.exists() && modelFile.length() > 0) {
-                Log.i(TAG, "Model already exists at: ${modelFile.absolutePath}")
-                onProgress?.invoke(1.0)
-                return@parallel modelFile.absolutePath
-            }
-            
-            Log.i(TAG, "Downloading model to temp file: ${tempFile.absolutePath}")
-            onProgress?.invoke(0.0)
-            
-            try {
-                val connection = java.net.URL(url).openConnection() as java.net.HttpURLConnection
-                connection.connectTimeout = 15000 // 15s
-                connection.readTimeout = 0 // Infinite for large files
-                connection.doInput = true
-                connection.connect()
-                
-                if (connection.responseCode != java.net.HttpURLConnection.HTTP_OK) {
-                    throw RuntimeException("Failed to download model: HTTP ${connection.responseCode}")
-                }
-                
-                val contentLength = connection.contentLengthLong // Use long for large files
-                val input = connection.inputStream
-                val output = java.io.FileOutputStream(tempFile)
-                
-                val buffer = ByteArray(8 * 1024)
-                var bytesRead: Int
-                var totalBytesRead = 0L
-                var lastProgressUpdate = 0L
-                
-                while (input.read(buffer).also { bytesRead = it } != -1) {
-                    output.write(buffer, 0, bytesRead)
-                    totalBytesRead += bytesRead
-                    
-                    if (contentLength > 0 && onProgress != null) {
-                        val currentTime = System.currentTimeMillis()
-                        // Update roughly every 100ms to avoid flooding JS bridge
-                        if (currentTime - lastProgressUpdate > 100) {
-                            val progress = totalBytesRead.toDouble() / contentLength.toDouble()
-                            onProgress(progress)
-                            lastProgressUpdate = currentTime
-                        }
-                    }
-                }
-                
-                output.flush()
-                output.close()
-                input.close()
-                connection.disconnect()
-                
-                // Atomic rename
-                if (tempFile.renameTo(modelFile)) {
-                    Log.i(TAG, "Download complete and renamed to: ${modelFile.absolutePath}")
-                    onProgress?.invoke(1.0)
-                    return@parallel modelFile.absolutePath
-                } else {
-                    throw RuntimeException("Failed to rename temp file to model file")
-                }
-                
-            } catch (e: Exception) {
-                Log.e(TAG, "Download failed", e)
-                if (tempFile.exists()) {
-                    tempFile.delete()
-                }
-                throw RuntimeException("Download failed: ${e.message}", e)
-            }
-        }
+        val store = HybridModelStore()
+        return store.downloadFile(url, fileName, "", onProgress ?: {})
     }
 
     override fun deleteModel(fileName: String): Promise<Unit> {
         return Promise.parallel {
-            Log.i(TAG, "deleteModel: $fileName")
-            
-            if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
-                throw IllegalArgumentException("Invalid filename: path traversal or directory separators are not allowed.")
-            }
-            
-            val context = LiteRTLMInitProvider.applicationContext ?: throw RuntimeException("Context not available")
-            val modelsDir = java.io.File(context.filesDir, "models")
-            val modelFile = java.io.File(modelsDir, fileName)
-            
-            if (modelFile.exists()) {
-                val deleted = modelFile.delete()
-                if (deleted) {
-                    Log.i(TAG, "Deleted model: ${modelFile.absolutePath}")
-                    // Ensure engine references are cleared if they point to this file
-                    // We use cleanupInternal() which releases resources WITHOUT marking the instance as closed.
-                    if (engine != null) {
-                        Log.i(TAG, "Cleaning up engine after deleting model file.")
-                        cleanupInternal()
-                    }
-                } else {
-                    Log.e(TAG, "Failed to delete model: ${modelFile.absolutePath}")
-                    throw RuntimeException("Failed to delete model: ${modelFile.absolutePath}")
-                }
-            } else {
-                Log.w(TAG, "Model not found for deletion: ${modelFile.absolutePath}")
+            val store = HybridModelStore()
+            store.deleteFile(fileName)
+            if (engine != null) {
+                cleanupInternal()
             }
         }
     }

--- a/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
+++ b/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
@@ -165,13 +165,21 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
                                 System.loadLibrary("OpenCL")
                                 true
                             } catch (_: UnsatisfiedLinkError) {
-                                try {
-                                    // Some devices have it at a non-standard path
-                                    System.load("/system/vendor/lib64/libOpenCL.so")
-                                    true
-                                } catch (_: UnsatisfiedLinkError) {
-                                    false
+                                val paths = arrayOf(
+                                    "/vendor/lib64/libOpenCL.so",
+                                    "/system/vendor/lib64/libOpenCL.so",
+                                    "/vendor/lib/libOpenCL.so",
+                                    "/system/lib64/libOpenCL.so"
+                                )
+                                var loaded = false
+                                for (path in paths) {
+                                    try {
+                                        System.load(path)
+                                        loaded = true
+                                        break
+                                    } catch (_: UnsatisfiedLinkError) {}
                                 }
+                                loaded
                             }
                             openCLAvailable = result
                             result

--- a/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridModelStore.kt
+++ b/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridModelStore.kt
@@ -1,0 +1,189 @@
+package com.margelo.nitro.dev.litert.litertlm
+
+import android.util.Log
+import androidx.annotation.Keep
+import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.Promise
+import dev.litert.litertlm.LiteRTLMInitProvider
+import java.io.File
+import java.io.FileOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import org.json.JSONObject
+
+@DoNotStrip
+@Keep
+class HybridModelStore : HybridModelStoreSpec() {
+
+    private val tag = "HybridModelStore"
+
+    private val modelsDirectory: File
+        get() {
+            val context = LiteRTLMInitProvider.applicationContext 
+                ?: throw RuntimeException("Android Application Context is not available")
+            val modelsDir = File(context.filesDir, "models")
+            if (!modelsDir.exists()) {
+                modelsDir.mkdirs()
+            }
+            return modelsDir
+        }
+
+    private fun sanitizeFileName(fileName: String) {
+        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+            throw IllegalArgumentException("Invalid filename: path traversal or directory separators are not allowed.")
+        }
+    }
+
+    override fun isCached(fileName: String): Boolean {
+        sanitizeFileName(fileName)
+        val file = File(modelsDirectory, fileName)
+        return file.exists() && file.length() > 0
+    }
+
+    override fun getFilePath(fileName: String): String {
+        sanitizeFileName(fileName)
+        return File(modelsDirectory, fileName).absolutePath
+    }
+
+    override fun listCachedFiles(): Array<ModelFile> {
+        return try {
+            val dir = modelsDirectory
+            val files = dir.listFiles() ?: return emptyArray()
+            val result = mutableListOf<ModelFile>()
+            for (f in files) {
+                if (f.isFile) {
+                    result.add(
+                        ModelFile(
+                            fileName = f.name,
+                            absolutePath = f.absolutePath,
+                            sizeBytes = f.length().toDouble(),
+                            lastModifiedMs = f.lastModified().toDouble()
+                        )
+                    )
+                }
+            }
+            result.toTypedArray()
+        } catch (e: Exception) {
+            Log.e(tag, "Failed to list cached files", e)
+            emptyArray()
+        }
+    }
+
+    override fun deleteFile(fileName: String) {
+        sanitizeFileName(fileName)
+        val file = File(modelsDirectory, fileName)
+        if (file.exists()) {
+            val deleted = file.delete()
+            if (!deleted) {
+                throw RuntimeException("Failed to delete model file: ${file.absolutePath}")
+            }
+        }
+    }
+
+    override fun downloadFile(
+        url: String,
+        fileName: String,
+        headersJson: String,
+        onProgress: (progress: Double) -> Unit
+    ): Promise<String> {
+        return Promise.parallel {
+            Log.i(tag, "downloadFile: $url -> $fileName")
+            sanitizeFileName(fileName)
+
+            if (!url.startsWith("https://", ignoreCase = true)) {
+                throw IllegalArgumentException("Invalid download URL: HTTPS is required for security.")
+            }
+
+            val dir = modelsDirectory
+            val modelFile = File(dir, fileName)
+            val tempFile = File(dir, "$fileName.tmp")
+
+            // Fast cache check
+            if (modelFile.exists() && modelFile.length() > 0) {
+                Log.i(tag, "Model already exists: ${modelFile.absolutePath}")
+                onProgress(1.0)
+                return@parallel modelFile.absolutePath
+            }
+
+            Log.i(tag, "Downloading model to temp file: ${tempFile.absolutePath}")
+            onProgress(0.0)
+
+            // Parse headers
+            val headersMap = mutableMapOf<String, String>()
+            if (headersJson.isNotEmpty()) {
+                try {
+                    val json = JSONObject(headersJson)
+                    val keys = json.keys()
+                    while (keys.hasNext()) {
+                        val key = keys.next()
+                        headersMap[key] = json.getString(key)
+                    }
+                } catch (e: Exception) {
+                    Log.e(tag, "Failed to parse custom headers JSON", e)
+                }
+            }
+
+            try {
+                val connection = URL(url).openConnection() as HttpURLConnection
+                connection.connectTimeout = 15000 // 15s
+                connection.readTimeout = 0 // Infinite read timeout for large files
+                connection.doInput = true
+
+                // Apply headers
+                for ((key, value) in headersMap) {
+                    connection.setRequestProperty(key, value)
+                }
+
+                connection.connect()
+
+                if (connection.responseCode != HttpURLConnection.HTTP_OK) {
+                    throw RuntimeException("Failed to download model: HTTP ${connection.responseCode}")
+                }
+
+                val contentLength = connection.contentLengthLong
+                val input = connection.inputStream
+                val output = FileOutputStream(tempFile)
+
+                val buffer = ByteArray(8 * 1024)
+                var bytesRead: Int
+                var totalBytesRead = 0L
+                var lastProgressUpdate = 0L
+
+                while (input.read(buffer).also { bytesRead = it } != -1) {
+                    output.write(buffer, 0, bytesRead)
+                    totalBytesRead += bytesRead
+
+                    if (contentLength > 0) {
+                        val currentTime = System.currentTimeMillis()
+                        // Update progress roughly every 100ms to prevent bridge flooding
+                        if (currentTime - lastProgressUpdate > 100) {
+                            val progress = totalBytesRead.toDouble() / contentLength.toDouble()
+                            onProgress(progress)
+                            lastProgressUpdate = currentTime
+                        }
+                    }
+                }
+
+                output.flush()
+                output.close()
+                input.close()
+                connection.disconnect()
+
+                // Atomic rename
+                if (tempFile.renameTo(modelFile)) {
+                    Log.i(tag, "Download complete and verified at: ${modelFile.absolutePath}")
+                    onProgress(1.0)
+                    modelFile.absolutePath
+                } else {
+                    throw RuntimeException("Failed to rename temporary file to model file")
+                }
+            } catch (e: Exception) {
+                Log.e(tag, "Download failed", e)
+                if (tempFile.exists()) {
+                    tempFile.delete()
+                }
+                throw RuntimeException("Download failed: ${e.message}", e)
+            }
+        }
+    }
+}

--- a/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/MultimodalPartFactories.kt
+++ b/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/MultimodalPartFactories.kt
@@ -1,0 +1,15 @@
+package com.margelo.nitro.dev.litert.litertlm
+
+/**
+ * Mirrors [src/inferenceRouting.ts] — keep shapes in sync for native direct hybrid access.
+ */
+object MultimodalPartFactories {
+    fun textPart(text: String): MultimodalPart =
+        MultimodalPart(type = PartType.TEXT, text = text, path = null, imageBuffer = null, audioBuffer = null)
+
+    fun imagePart(path: String): MultimodalPart =
+        MultimodalPart(type = PartType.IMAGE, text = null, path = path, imageBuffer = null, audioBuffer = null)
+
+    fun audioPart(path: String): MultimodalPart =
+        MultimodalPart(type = PartType.AUDIO, text = null, path = path, imageBuffer = null, audioBuffer = null)
+}

--- a/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/StreamingCallbackListener.kt
+++ b/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/StreamingCallbackListener.kt
@@ -1,0 +1,73 @@
+package com.margelo.nitro.dev.litert.litertlm
+
+import android.util.Log
+import com.google.ai.edge.litertlm.Content
+
+/**
+ * Named implementation of the LiteRT-LM MessageCallback for streaming inference.
+ *
+ * Accumulates response chunks, forwards tokens to JS, and appends the final
+ * response to the conversation history.
+ */
+internal class StreamingCallbackListener(
+    private val onToken: (String, Boolean) -> Unit,
+    private val responseBuilder: StringBuilder,
+    private val history: MutableList<Message>,
+    private val userMessage: String,
+    private val onStatsReady: (GenerationStats) -> Unit,
+    private val onFailure: ((Throwable) -> Unit)? = null,
+) : com.google.ai.edge.litertlm.MessageCallback {
+
+    private val startTime = System.nanoTime()
+    private var firstTokenTime = 0L
+    private var tokenCount = 0
+
+    override fun onMessage(message: com.google.ai.edge.litertlm.Message) {
+        val chunk = message.contents.contents
+            .filterIsInstance<Content.Text>()
+            .joinToString("") { it.text }
+
+        if (firstTokenTime == 0L && chunk.isNotEmpty()) {
+            firstTokenTime = System.nanoTime()
+        }
+        if (chunk.isNotEmpty()) {
+            tokenCount++
+        }
+
+        onToken(chunk, false)
+
+        if (chunk.isNotEmpty()) {
+            responseBuilder.append(chunk)
+        }
+    }
+
+    override fun onDone() {
+        val fullResponse = responseBuilder.toString()
+        history.add(Message(Role.MODEL, fullResponse))
+
+        // Compute stats using heuristic token counts (~4 chars/token)
+        val elapsedMs = (System.nanoTime() - startTime) / 1_000_000.0
+        val ttftMs = if (firstTokenTime > 0) (firstTokenTime - startTime) / 1_000_000.0 else 0.0
+        val promptTokens = userMessage.length / 4.0
+        val completionTokens = fullResponse.length / 4.0
+        onStatsReady(GenerationStats(
+            promptTokens = promptTokens,
+            completionTokens = completionTokens,
+            totalTokens = promptTokens + completionTokens,
+            timeToFirstToken = ttftMs,
+            totalTime = elapsedMs,
+            tokensPerSecond = if (elapsedMs > 0) completionTokens / (elapsedMs / 1000.0) else 0.0
+        ))
+
+        Log.d("StreamingCallbackListener", "Streaming done. Length: ${fullResponse.length}, TTFT: ${ttftMs.toLong()}ms, Total: ${elapsedMs.toLong()}ms")
+
+        // Notify JS that streaming is done AFTER updating history and stats
+        onToken("", true)
+    }
+
+    override fun onError(throwable: Throwable) {
+        Log.e("StreamingCallbackListener", "Async generation failed", throwable)
+        onToken("Error: ${throwable.message}", true)
+        onFailure?.invoke(throwable)
+    }
+}

--- a/android/src/test/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLMTest.kt
+++ b/android/src/test/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLMTest.kt
@@ -102,4 +102,21 @@ class HybridLiteRTLMTest {
         assertEquals(0.0, stats.totalTime, 0.0)
         assertEquals(0.0, stats.tokensPerSecond, 0.0)
     }
+
+    @Test
+    fun testDeleteModelCleanupLogic() {
+        val loadedPathField = HybridLiteRTLM::class.java.getDeclaredField("loadedModelPath")
+        loadedPathField.isAccessible = true
+        loadedPathField.set(bridge, "/path/to/my_loaded_model.litertlm")
+
+        val promise1 = bridge.deleteModel("other_model.litertlm")
+        assertNotNull(promise1)
+        while (!promise1.isCompleted) { Thread.sleep(10) }
+        assertEquals("/path/to/my_loaded_model.litertlm", loadedPathField.get(bridge))
+
+        val promise2 = bridge.deleteModel("my_loaded_model.litertlm")
+        assertNotNull(promise2)
+        while (!promise2.isCompleted) { Thread.sleep(10) }
+        assertNull(loadedPathField.get(bridge))
+    }
 }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -34,14 +34,7 @@ import {
 const TEST_IMAGE_ASSET = require("./test.jpeg");
 const TEST_AUDIO_ASSET = require("./test.wav");
 
-async function getTestImagePath(inst?: any): Promise<string> {
-  if (Platform.OS === "android") return "/data/local/tmp/test.jpeg";
-  const src = Image.resolveAssetSource(TEST_IMAGE_ASSET);
-  if (src.uri.startsWith("file://")) return src.uri.replace("file://", "");
-  if (inst?.downloadModel)
-    return inst.downloadModel(src.uri, "test_image.jpeg");
-  throw new Error("Cannot resolve test image in dev mode");
-}
+
 
 // ─── Theme ───────────────────────────────────────────────────────────────────
 const T = {
@@ -119,19 +112,19 @@ function Main() {
       enableSpeculativeDecoding,
       tools: enableTools
         ? [
-            {
-              name: "get_current_weather",
-              description: "Get the current weather for a location",
-              parametersJson: JSON.stringify({
-                type: "object",
-                properties: {
-                  location: { type: "string", description: "The city and state, e.g. San Francisco, CA" },
-                  unit: { type: "string", enum: ["celsius", "fahrenheit"] }
-                },
-                required: ["location"]
-              })
-            }
-          ]
+          {
+            name: "get_current_weather",
+            description: "Get the current weather for a location",
+            parametersJson: JSON.stringify({
+              type: "object",
+              properties: {
+                location: { type: "string", description: "The city and state, e.g. San Francisco, CA" },
+                unit: { type: "string", enum: ["celsius", "fahrenheit"] }
+              },
+              required: ["location"]
+            })
+          }
+        ]
         : undefined,
     }),
     [backend, enableSpeculativeDecoding, enableTools],
@@ -171,54 +164,42 @@ function Main() {
     setStreaming("");
 
     try {
-      if (currentAttachment) {
-        setStreaming("Reading attachment and generating response...");
-        const parts: any[] = [];
-        
-        if (currentAttachment === "image") {
-          const uri = Image.resolveAssetSource(TEST_IMAGE_ASSET).uri;
-          const response = await fetch(uri);
-          const buffer = await response.arrayBuffer();
-          parts.push({ type: "image", imageBuffer: buffer });
-        } else if (currentAttachment === "audio") {
-          const uri = Image.resolveAssetSource(TEST_AUDIO_ASSET).uri;
-          const response = await fetch(uri);
-          const buffer = await response.arrayBuffer();
-          parts.push({ type: "audio", audioBuffer: buffer });
-        }
-        
-        if (msg) {
-          parts.push({ type: "text", text: msg });
-        }
+      const parts: any[] = [];
 
-        const reply = await model.sendMultimodalMessage(parts);
-        setChat((prev) => [
-          ...prev,
-          { role: "model", text: reply, ts: Date.now() },
-        ]);
-        setStreaming("");
-      } else {
-        await new Promise<void>((resolve, reject) => {
-          let full = "";
-          model.sendMessageAsync(msg, (token: string, done: boolean) => {
-            if (!done) {
-              full += token;
-              setStreaming(full);
-            } else {
-              setChat((prev) => [
-                ...prev,
-                { role: "model", text: full, ts: Date.now() },
-              ]);
-              setStreaming("");
-              resolve();
-            }
-          }).catch(reject);
-        });
+      if (currentAttachment === "image") {
+        const uri = Image.resolveAssetSource(TEST_IMAGE_ASSET).uri;
+        const response = await fetch(uri);
+        const buffer = await response.arrayBuffer();
+        parts.push({ type: "image", imageBuffer: buffer });
+      } else if (currentAttachment === "audio") {
+        const uri = Image.resolveAssetSource(TEST_AUDIO_ASSET).uri;
+        const response = await fetch(uri);
+        const buffer = await response.arrayBuffer();
+        parts.push({ type: "audio", audioBuffer: buffer });
       }
+
+      if (msg) {
+        parts.push({ type: "text", text: msg });
+      }
+
+      setStreaming(currentAttachment ? "Reading attachment..." : "");
+
+      let full = "";
+      const reply = await model.execute(parts, (token) => {
+        full += token;
+        setStreaming(full);
+      });
+
+      setChat((prev) => [
+        ...prev,
+        { role: "model", text: reply, ts: Date.now() },
+      ]);
+      setStreaming("");
+
       // Refresh memory stats
       try {
         setLiveMemory(model.getMemoryUsage());
-      } catch {}
+      } catch { }
     } catch (e: any) {
       setChat((prev) => [
         ...prev,
@@ -402,7 +383,7 @@ function Main() {
                       : "gemma-3n-E2B-it-int4.litertlm";
                   try {
                     await deleteModel(fn);
-                  } catch {}
+                  } catch { }
                 }}
               >
                 <Text style={s.dangerText}>Delete Cached Model</Text>
@@ -543,7 +524,7 @@ function Main() {
                 </TouchableOpacity>
               </View>
             )}
-            
+
             <View style={s.inputBar}>
               <TouchableOpacity
                 style={s.attachBtn}
@@ -565,7 +546,7 @@ function Main() {
               >
                 <Text style={s.attachIcon}>📎</Text>
               </TouchableOpacity>
-              
+
               <TextInput
                 style={s.input}
                 placeholder={attachment ? "Add message with attachment..." : "Message…"}

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -23,7 +23,7 @@
       }
     },
     "..": {
-      "version": "0.4.0",
+      "version": "0.4.2",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/ios/HybridLiteRTLM+Execute.swift
+++ b/ios/HybridLiteRTLM+Execute.swift
@@ -1,0 +1,266 @@
+//
+//  HybridLiteRTLM+Execute.swift
+//  react-native-litert-lm
+//
+//  Unified inference pipeline (execute). JS routes via src/inferenceRouting.ts;
+//  legacy send* methods below delegate here for direct native hybrid access.
+//
+
+import Foundation
+import UIKit
+import NitroModules
+import CLiteRTLM
+
+
+
+// MARK: - Preprocessed parts for thread-safety
+
+struct PreprocessedPart {
+    enum Kind {
+        case text(String)
+        case imagePath(String)
+        case imageData(Data)
+        case audioPath(String)
+        case audioData(Data)
+    }
+    let kind: Kind
+    let label: String
+}
+
+// MARK: - Execute pipeline
+
+extension HybridLiteRTLM {
+
+    /// Only used when legacy native *Async methods are invoked directly (not via createLLM JS proxy).
+    func executeVoid(
+        parts: [MultimodalPart],
+        onToken: @escaping (_ token: String, _ done: Bool) -> Void
+    ) throws -> Promise<Void> {
+        let voidPromise = Promise<Void>()
+        let resultPromise = try execute(parts: parts, onToken: onToken)
+        resultPromise
+            .then { _ in voidPromise.resolve() }
+            .catch { voidPromise.reject(withError: $0) }
+        return voidPromise
+    }
+
+    public func execute(parts: [MultimodalPart], onToken: ((_ token: String, _ done: Bool) -> Void)?) throws -> Promise<String> {
+        let promise = Promise<String>()
+
+        // Preprocess all JSI-bound data on the caller thread synchronously
+        var preprocessed: [PreprocessedPart] = []
+        for part in parts {
+            switch part.type {
+            case .text:
+                let txt = part.text ?? ""
+                preprocessed.append(PreprocessedPart(kind: .text(txt), label: txt))
+            case .image:
+                if let path = part.path {
+                    preprocessed.append(PreprocessedPart(kind: .imagePath(path), label: "[Image]"))
+                } else if let buf = part.imageBuffer {
+                    let data = buf.toData(copyIfNeeded: true)
+                    preprocessed.append(PreprocessedPart(kind: .imageData(data), label: "[Image]"))
+                }
+            case .audio:
+                if let path = part.path {
+                    preprocessed.append(PreprocessedPart(kind: .audioPath(path), label: "[Audio]"))
+                } else if let buf = part.audioBuffer {
+                    let data = buf.toData(copyIfNeeded: true)
+                    preprocessed.append(PreprocessedPart(kind: .audioData(data), label: "[Audio]"))
+                }
+            }
+        }
+
+        let userLabel = preprocessed.map { $0.label }.joined(separator: " ").trimmingCharacters(in: .whitespaces)
+
+        queue.async {
+            guard let conversation = self.conversation else {
+                promise.reject(withError: NSError(domain: "LiteRTLM", code: 400,
+                    userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: No model loaded. Call loadModel() first."]))
+                return
+            }
+
+            let payload: (json: String, tempFiles: [String])
+            do { payload = try self.buildExecutePayload(preprocessed) }
+            catch { promise.reject(withError: error); return }
+
+            let msgJson = payload.json
+            let tempFiles = payload.tempFiles
+            let cleanup = { tempFiles.forEach { try? FileManager.default.removeItem(atPath: $0) } }
+
+            if let onToken = onToken {
+                self.runExecuteStreaming(
+                    conversation: conversation,
+                    msgJson: msgJson,
+                    userLabel: userLabel,
+                    onToken: onToken,
+                    promise: promise,
+                    cleanup: cleanup
+                )
+            } else {
+                self.runExecuteBlocking(
+                    conversation: conversation,
+                    msgJson: msgJson,
+                    userLabel: userLabel,
+                    promise: promise,
+                    cleanup: cleanup
+                )
+            }
+        }
+
+        return promise
+    }
+
+    // MARK: - Payload / media
+
+    private func validateMediaPath(_ path: String, label: String) throws {
+        if !FileManager.default.fileExists(atPath: path) {
+            throw NSError(
+                domain: "LiteRTLM", code: 404,
+                userInfo: [NSLocalizedDescriptionKey: "\(label) file not found: \(path)"]
+            )
+        }
+    }
+
+    private func buildExecutePayload(_ preprocessed: [PreprocessedPart]) throws -> (json: String, tempFiles: [String]) {
+        struct Desc { let kind: String; let text: String?; let file: String? }
+        var descs: [Desc] = []
+        var temps: [String] = []
+
+        for part in preprocessed {
+            switch part.kind {
+            case .text(let text):
+                descs.append(Desc(kind: "text", text: text, file: nil))
+            case .imagePath(let path):
+                try validateMediaPath(path, label: "Image")
+                let scaled = scaleImageIfNeeded(path)
+                if scaled != path { temps.append(scaled) }
+                descs.append(Desc(kind: "image", text: nil, file: scaled))
+            case .imageData(let data):
+                let raw = try saveDataToTempFile(data, ext: "jpg")
+                temps.append(raw)
+                let scaled = scaleImageIfNeeded(raw)
+                if scaled != raw { temps.append(scaled) }
+                descs.append(Desc(kind: "image", text: nil, file: scaled))
+            case .audioPath(let path):
+                try validateMediaPath(path, label: "Audio")
+                descs.append(Desc(kind: "audio", text: nil, file: path))
+            case .audioData(let data):
+                let raw = try saveDataToTempFile(data, ext: "wav")
+                temps.append(raw)
+                descs.append(Desc(kind: "audio", text: nil, file: raw))
+            }
+        }
+
+        if descs.count == 1 && descs[0].kind == "text" {
+            return (buildTextMessageJson(text: descs[0].text ?? ""), temps)
+        }
+
+        let partsJson = descs.map { d -> String in
+            switch d.kind {
+            case "text":  return "{\"type\":\"text\",\"text\":\"" + escapeJson(d.text ?? "") + "\"}"
+            case "image": return "{\"type\":\"image\",\"path\":\"" + escapeJson(d.file ?? "") + "\"}"
+            default:      return "{\"type\":\"audio\",\"path\":\"" + escapeJson(d.file ?? "") + "\"}"
+            }
+        }.joined(separator: ",")
+        return ("{\"role\":\"user\",\"content\":[" + partsJson + "]}", temps)
+    }
+
+    private func buildTextMessageJson(text: String) -> String {
+        return "{\"role\":\"user\",\"content\":\"" + escapeJson(text) + "\"}"
+    }
+
+    private func scaleImageIfNeeded(_ imagePath: String, maxDimension: Int = 1024) -> String {
+        guard let image = UIImage(contentsOfFile: imagePath) else { return imagePath }
+        let w = Int(image.size.width), h = Int(image.size.height)
+        guard max(w, h) > maxDimension else { return imagePath }
+        let scale = CGFloat(maxDimension) / CGFloat(max(w, h))
+        let newSize = CGSize(width: CGFloat(w) * scale, height: CGFloat(h) * scale)
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        let scaled = renderer.image { _ in image.draw(in: CGRect(origin: .zero, size: newSize)) }
+        let tmp = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("litert_scaled_\(Int(Date().timeIntervalSince1970 * 1_000)).jpg")
+        if let data = scaled.jpegData(compressionQuality: 0.9) {
+            try? data.write(to: URL(fileURLWithPath: tmp))
+        }
+        return tmp
+    }
+
+    private func saveDataToTempFile(_ data: Data, ext: String) throws -> String {
+        let tmp = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("litert_buf_\(Int(Date().timeIntervalSince1970 * 1_000)).\(ext)")
+        try data.write(to: URL(fileURLWithPath: tmp))
+        return tmp
+    }
+
+    // MARK: - Streaming / blocking runners
+
+    private func runExecuteBlocking(
+        conversation: OpaquePointer,
+        msgJson: String,
+        userLabel: String,
+        promise: Promise<String>,
+        cleanup: @escaping () -> Void
+    ) {
+        let startTime = Date()
+        guard let response = litert_lm_conversation_send_message(conversation, msgJson, nil, nil) else {
+            cleanup()
+            promise.reject(withError: NSError(domain: "LiteRTLM", code: 500,
+                userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: execute failed."]))
+            return
+        }
+        defer { litert_lm_json_response_delete(response) }
+
+        var result = ""
+        if let rs = litert_lm_json_response_get_string(response) {
+            result = extractTextFromResponse(String(cString: rs))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        commitExecuteTurn(
+            userLabel: userLabel,
+            modelResponse: result,
+            startTime: startTime,
+            conversation: conversation,
+            tokenCount: 0
+        )
+        cleanup()
+        promise.resolve(withResult: result)
+    }
+
+
+
+    func commitExecuteTurn(
+        userLabel: String,
+        modelResponse: String,
+        startTime: Date,
+        conversation: OpaquePointer?,
+        tokenCount: Int
+    ) {
+        let totalTime = Date().timeIntervalSince(startTime)
+        var compTok = Double(tokenCount)
+        var tps = 0.0, ttft = 0.0
+        if let conversation = conversation,
+           let bi = litert_lm_conversation_get_benchmark_info(conversation) {
+            let turns = litert_lm_benchmark_info_get_num_decode_turns(bi)
+            if turns > 0 {
+                let li = turns - 1
+                tps = litert_lm_benchmark_info_get_decode_tokens_per_sec_at(bi, li)
+                compTok = Double(litert_lm_benchmark_info_get_decode_token_count_at(bi, li))
+            }
+            ttft = litert_lm_benchmark_info_get_time_to_first_token(bi)
+            litert_lm_benchmark_info_delete(bi)
+        }
+        let pt = Double(userLabel.count) / 4.0
+        if compTok == 0.0 { compTok = Double(modelResponse.count) / 4.0 }
+        lastStats = GenerationStats(
+            promptTokens: pt, completionTokens: compTok,
+            totalTokens: pt + compTok, timeToFirstToken: ttft,
+            totalTime: totalTime,
+            tokensPerSecond: tps > 0 ? tps : (compTok / totalTime)
+        )
+        history.append(Message(role: .user, content: userLabel))
+        history.append(Message(role: .model, content: modelResponse))
+    }
+}
+

--- a/ios/HybridLiteRTLM+Execute.swift
+++ b/ios/HybridLiteRTLM+Execute.swift
@@ -127,29 +127,34 @@ extension HybridLiteRTLM {
         var descs: [Desc] = []
         var temps: [String] = []
 
-        for part in preprocessed {
-            switch part.kind {
-            case .text(let text):
-                descs.append(Desc(kind: "text", text: text, file: nil))
-            case .imagePath(let path):
-                try validateMediaPath(path, label: "Image")
-                let scaled = scaleImageIfNeeded(path)
-                if scaled != path { temps.append(scaled) }
-                descs.append(Desc(kind: "image", text: nil, file: scaled))
-            case .imageData(let data):
-                let raw = try saveDataToTempFile(data, ext: "jpg")
-                temps.append(raw)
-                let scaled = scaleImageIfNeeded(raw)
-                if scaled != raw { temps.append(scaled) }
-                descs.append(Desc(kind: "image", text: nil, file: scaled))
-            case .audioPath(let path):
-                try validateMediaPath(path, label: "Audio")
-                descs.append(Desc(kind: "audio", text: nil, file: path))
-            case .audioData(let data):
-                let raw = try saveDataToTempFile(data, ext: "wav")
-                temps.append(raw)
-                descs.append(Desc(kind: "audio", text: nil, file: raw))
+        do {
+            for part in preprocessed {
+                switch part.kind {
+                case .text(let text):
+                    descs.append(Desc(kind: "text", text: text, file: nil))
+                case .imagePath(let path):
+                    try validateMediaPath(path, label: "Image")
+                    let scaled = scaleImageIfNeeded(path)
+                    if scaled != path { temps.append(scaled) }
+                    descs.append(Desc(kind: "image", text: nil, file: scaled))
+                case .imageData(let data):
+                    let raw = try saveDataToTempFile(data, ext: "jpg")
+                    temps.append(raw)
+                    let scaled = scaleImageIfNeeded(raw)
+                    if scaled != raw { temps.append(scaled) }
+                    descs.append(Desc(kind: "image", text: nil, file: scaled))
+                case .audioPath(let path):
+                    try validateMediaPath(path, label: "Audio")
+                    descs.append(Desc(kind: "audio", text: nil, file: path))
+                case .audioData(let data):
+                    let raw = try saveDataToTempFile(data, ext: "wav")
+                    temps.append(raw)
+                    descs.append(Desc(kind: "audio", text: nil, file: raw))
+                }
             }
+        } catch {
+            temps.forEach { try? FileManager.default.removeItem(atPath: $0) }
+            throw error
         }
 
         if descs.count == 1 && descs[0].kind == "text" {
@@ -179,7 +184,7 @@ extension HybridLiteRTLM {
         let renderer = UIGraphicsImageRenderer(size: newSize)
         let scaled = renderer.image { _ in image.draw(in: CGRect(origin: .zero, size: newSize)) }
         let tmp = (NSTemporaryDirectory() as NSString)
-            .appendingPathComponent("litert_scaled_\(Int(Date().timeIntervalSince1970 * 1_000)).jpg")
+            .appendingPathComponent("litert_scaled_\(UUID().uuidString).jpg")
         if let data = scaled.jpegData(compressionQuality: 0.9) {
             try? data.write(to: URL(fileURLWithPath: tmp))
         }
@@ -188,7 +193,7 @@ extension HybridLiteRTLM {
 
     private func saveDataToTempFile(_ data: Data, ext: String) throws -> String {
         let tmp = (NSTemporaryDirectory() as NSString)
-            .appendingPathComponent("litert_buf_\(Int(Date().timeIntervalSince1970 * 1_000)).\(ext)")
+            .appendingPathComponent("litert_buf_\(UUID().uuidString).\(ext)")
         try data.write(to: URL(fileURLWithPath: tmp))
         return tmp
     }

--- a/ios/HybridLiteRTLM+Streaming.swift
+++ b/ios/HybridLiteRTLM+Streaming.swift
@@ -1,0 +1,152 @@
+//
+//  HybridLiteRTLM+Streaming.swift
+//  react-native-litert-lm
+//
+//  Streaming context and callback runners for the unified execute pipeline.
+//
+
+import Foundation
+import NitroModules
+import CLiteRTLM
+
+class ExecuteStreamContext {
+    let userLabel: String
+    let startTime: Date
+    let onToken: (_ token: String, _ done: Bool) -> Void
+    let promise: Promise<String>
+    let parent: HybridLiteRTLM
+    let cleanup: () -> Void
+    var rawResponse: String = ""
+    var fullResponse: String = ""
+    var lastEmittedLength: Int = 0
+    var tokenCount: Int = 0
+
+    init(
+        userLabel: String,
+        startTime: Date,
+        onToken: @escaping (_ token: String, _ done: Bool) -> Void,
+        promise: Promise<String>,
+        parent: HybridLiteRTLM,
+        cleanup: @escaping () -> Void
+    ) {
+        self.userLabel = userLabel
+        self.startTime = startTime
+        self.onToken = onToken
+        self.promise = promise
+        self.parent = parent
+        self.cleanup = cleanup
+    }
+}
+
+extension HybridLiteRTLM {
+
+    func runExecuteStreaming(
+        conversation: OpaquePointer,
+        msgJson: String,
+        userLabel: String,
+        onToken: @escaping (_ token: String, _ done: Bool) -> Void,
+        promise: Promise<String>,
+        cleanup: @escaping () -> Void
+    ) {
+        let ctx = ExecuteStreamContext(
+            userLabel: userLabel, startTime: Date(),
+            onToken: onToken, promise: promise, parent: self,
+            cleanup: cleanup
+        )
+        let ptr = Unmanaged.passRetained(ctx).toOpaque()
+
+        let cb: LiteRtLmStreamCallback = { ptr, chunk, isFinal, errorMsg in
+            guard let ptr = ptr else { return }
+            let ctx = Unmanaged<ExecuteStreamContext>.fromOpaque(ptr).takeUnretainedValue()
+
+            if let errorMsg = errorMsg {
+                let msg = String(cString: errorMsg)
+                ctx.onToken("Error: \(msg)", true)
+                ctx.cleanup()
+                ctx.promise.reject(withError: NSError(domain: "LiteRTLM", code: 500,
+                    userInfo: [NSLocalizedDescriptionKey: msg]))
+                Unmanaged<ExecuteStreamContext>.fromOpaque(ptr).release()
+                return
+            }
+
+            if isFinal {
+                ctx.parent.finalizeExecuteStream(ctx: ctx, streamPtr: ptr)
+                return
+            }
+
+            if let chunk = chunk {
+                ctx.parent.emitExecuteStreamChunk(ctx: ctx, chunk: chunk)
+            }
+        }
+
+        let status = litert_lm_conversation_send_message_stream(
+            conversation, msgJson, nil, nil, cb, ptr)
+        if status != 0 {
+            Unmanaged<ExecuteStreamContext>.fromOpaque(ptr).release()
+            cleanup()
+            promise.reject(withError: NSError(domain: "LiteRTLM", code: Int(status),
+                userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: execute streaming failed."]))
+        }
+    }
+
+    func finalizeExecuteStream(ctx: ExecuteStreamContext, streamPtr: UnsafeMutableRawPointer) {
+        let cleaned = stripControlTokens(ctx.rawResponse)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        var finalText = cleaned
+        if !ctx.userLabel.isEmpty && finalText.hasPrefix(ctx.userLabel) {
+            finalText = String(finalText.dropFirst(ctx.userLabel.count))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if finalText.count > ctx.lastEmittedLength {
+            let si = finalText.index(finalText.startIndex, offsetBy: ctx.lastEmittedLength)
+            ctx.onToken(String(finalText[si...]), false)
+        }
+        ctx.fullResponse = finalText
+
+        queue.async {
+            self.commitExecuteTurn(
+                userLabel: ctx.userLabel,
+                modelResponse: ctx.fullResponse,
+                startTime: ctx.startTime,
+                conversation: self.conversation,
+                tokenCount: ctx.tokenCount
+            )
+            ctx.onToken("", true)
+            ctx.cleanup()
+            ctx.promise.resolve(withResult: ctx.fullResponse)
+            Unmanaged<ExecuteStreamContext>.fromOpaque(streamPtr).release()
+        }
+    }
+
+    func emitExecuteStreamChunk(ctx: ExecuteStreamContext, chunk: UnsafePointer<CChar>) {
+        let token = String(cString: chunk)
+        let raw = token.hasPrefix("{") && token.contains("\"role\"")
+            ? extractTextFromResponse(token) : token
+        ctx.rawResponse += raw
+        let cleaned = stripControlTokens(ctx.rawResponse)
+            .trimmingLeadingCharacters(in: .whitespacesAndNewlines)
+        var processed = cleaned
+        if !ctx.userLabel.isEmpty && processed.hasPrefix(ctx.userLabel) {
+            processed = String(processed.dropFirst(ctx.userLabel.count))
+                .trimmingLeadingCharacters(in: .whitespacesAndNewlines)
+        }
+        let safe = safeEmitLength(processed)
+        if safe > ctx.lastEmittedLength {
+            let chars = Array(processed)
+            ctx.onToken(String(chars[ctx.lastEmittedLength..<safe]), false)
+            ctx.lastEmittedLength = safe
+            ctx.tokenCount += 1
+        }
+    }
+}
+
+private extension String {
+    func trimmingLeadingCharacters(in characterSet: CharacterSet) -> String {
+        guard let index = firstIndex(where: { char in
+            !char.unicodeScalars.allSatisfy { characterSet.contains($0) }
+        }) else {
+            return ""
+        }
+        return String(self[index...])
+    }
+}

--- a/ios/HybridLiteRTLM.swift
+++ b/ios/HybridLiteRTLM.swift
@@ -1029,103 +1029,15 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
         fileName: String,
         onProgress: ((Double) -> Void)?
     ) throws -> Promise<String> {
-        let promise = Promise<String>()
-        
-        queue.async {
-            do {
-                if fileName.contains("..") || fileName.contains("/") || fileName.contains("\\") {
-                    promise.reject(withError: NSError(domain: "LiteRTLM", code: 400, userInfo: [NSLocalizedDescriptionKey: "Invalid filename: path traversal or directory separators are not allowed."]))
-                    return
-                }
-                
-                let cachesDir = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first ?? NSTemporaryDirectory()
-                let modelsDir = (cachesDir as NSString).appendingPathComponent("litert_models")
-                
-                let fileManager = FileManager.default
-                if !fileManager.fileExists(atPath: modelsDir) {
-                    try fileManager.createDirectory(atPath: modelsDir, withIntermediateDirectories: true, attributes: nil)
-                }
-                
-                let destPath = (modelsDir as NSString).appendingPathComponent(fileName)
-                
-                // Fast cache check
-                if fileManager.fileExists(atPath: destPath) {
-                    let attrs = try fileManager.attributesOfItem(atPath: destPath)
-                    if let fileSize = attrs[.size] as? UInt64, fileSize > 0 {
-                        onProgress?(1.0)
-                        promise.resolve(withResult: destPath)
-                        return
-                    }
-                }
-                
-                guard let downloadUrl = URL(string: url), downloadUrl.scheme?.lowercased() == "https" else {
-                    promise.reject(withError: NSError(domain: "LiteRTLM", code: 400, userInfo: [NSLocalizedDescriptionKey: "Invalid download URL: HTTPS is required for security."]))
-                    return
-                }
-                
-                onProgress?(0.0)
-                
-                let sessionConfig = URLSessionConfiguration.default
-                sessionConfig.timeoutIntervalForRequest = 30
-                sessionConfig.timeoutIntervalForResource = 3600
-                
-                let session = URLSession(configuration: sessionConfig)
-                var progressHandler: NSKeyValueObservation?
-                
-                let task = session.downloadTask(with: downloadUrl) { location, response, error in
-                    progressHandler?.invalidate()
-                    
-                    if let error = error {
-                        promise.reject(withError: error)
-                        return
-                    }
-                    
-                    if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode >= 400 {
-                        promise.reject(withError: NSError(domain: "LiteRTLM", code: httpResponse.statusCode, userInfo: [NSLocalizedDescriptionKey: "HTTP \(httpResponse.statusCode)"]))
-                        return
-                    }
-                    
-                    guard let location = location else {
-                        promise.reject(withError: NSError(domain: "LiteRTLM", code: 500, userInfo: [NSLocalizedDescriptionKey: "No download location found."]))
-                        return
-                    }
-                    
-                    do {
-                        if fileManager.fileExists(atPath: destPath) {
-                            try fileManager.removeItem(atPath: destPath)
-                        }
-                        try fileManager.moveItem(at: location, to: URL(fileURLWithPath: destPath))
-                        onProgress?(1.0)
-                        promise.resolve(withResult: destPath)
-                    } catch {
-                        promise.reject(withError: error)
-                    }
-                }
-                
-                if let onProgress = onProgress {
-                    var lastUpdate = Date()
-                    progressHandler = task.observe(\.countOfBytesReceived, options: [.new]) { task, _ in
-                        let expected = task.countOfBytesExpectedToReceive
-                        if expected > 0 {
-                            let now = Date()
-                            // Throttled progress notifications to 10Hz
-                            if now.timeIntervalSince(lastUpdate) > 0.1 {
-                                let progress = Double(task.countOfBytesReceived) / Double(expected)
-                                onProgress(progress)
-                                lastUpdate = now
-                            }
-                        }
-                    }
-                }
-                
-                task.resume()
-                session.finishTasksAndInvalidate()
-            } catch {
-                promise.reject(withError: error)
+        let store = HybridModelStore()
+        return try store.downloadFile(
+            url: url,
+            fileName: fileName,
+            headersJson: "",
+            onProgress: { progress in
+                onProgress?(progress)
             }
-        }
-        
-        return promise
+        )
     }
     
     public func deleteModel(fileName: String) throws -> Promise<Void> {
@@ -1133,21 +1045,10 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
         
         queue.async {
             do {
-                if fileName.contains("..") || fileName.contains("/") || fileName.contains("\\") {
-                    promise.reject(withError: NSError(domain: "LiteRTLM", code: 400, userInfo: [NSLocalizedDescriptionKey: "Invalid filename: path traversal or directory separators are not allowed."]))
-                    return
-                }
-                
-                let cachesDir = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first ?? NSTemporaryDirectory()
-                let modelsDir = (cachesDir as NSString).appendingPathComponent("litert_models")
-                let destPath = (modelsDir as NSString).appendingPathComponent(fileName)
-                
-                let fileManager = FileManager.default
-                if fileManager.fileExists(atPath: destPath) {
-                    try fileManager.removeItem(atPath: destPath)
-                    if self.isLoaded {
-                        self.closeInternal()
-                    }
+                let store = HybridModelStore()
+                try store.deleteFile(fileName: fileName)
+                if self.isLoaded {
+                    self.closeInternal()
                 }
                 promise.resolve()
             } catch {

--- a/ios/HybridLiteRTLM.swift
+++ b/ios/HybridLiteRTLM.swift
@@ -13,17 +13,13 @@ import os
 
 public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protocol {
     
+    // MARK: - Internal (for extension files)
+    
     /// Dedicated background serial queue to protect the JSI/JS thread from blocking and deadlocks (User Rule #1).
     let queue = DispatchQueue(label: "dev.litert.engine", qos: .userInteractive)
     
-    /// Opaque pointer to the LiteRT LM C Engine.
-    private var engine: OpaquePointer?
-    
     /// Opaque pointer to the active conversation state.
     var conversation: OpaquePointer?
-    
-    /// Thread-safe status flag.
-    private var isLoaded = false
     
     /// Conversation history.
     var history: [Message] = []
@@ -37,6 +33,17 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
         totalTime: 0.0,
         tokensPerSecond: 0.0
     )
+    
+    var loadedModelPath: String?
+    let modelStore = HybridModelStore()
+    
+    // MARK: - Private state
+    
+    /// Opaque pointer to the LiteRT LM C Engine.
+    private var engine: OpaquePointer?
+    
+    /// Thread-safe status flag.
+    private var isLoaded = false
     
     // Default configuration variables
     private var backend: Backend = .cpu
@@ -257,6 +264,7 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
             
             self.engine = engine
             self.createNewConversation()
+            self.loadedModelPath = modelPath
             
             guard self.conversation != nil else {
                 self.closeInternal()
@@ -314,11 +322,10 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
         fileName: String,
         onProgress: ((Double) -> Void)?
     ) throws -> Promise<String> {
-        let store = HybridModelStore()
-        return try store.downloadFile(
+        return try modelStore.downloadFile(
             url: url,
             fileName: fileName,
-            headersJson: "",
+            headersJson: "{}",
             onProgress: { progress in
                 onProgress?(progress)
             }
@@ -330,10 +337,12 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
         
         queue.async {
             do {
-                let store = HybridModelStore()
-                try store.deleteFile(fileName: fileName)
-                if self.isLoaded {
-                    self.closeInternal()
+                try self.modelStore.deleteFile(fileName: fileName)
+                let currentlyLoadedName = self.loadedModelPath.map { ($0 as NSString).lastPathComponent.lowercased() }
+                if let loadedName = currentlyLoadedName, loadedName == fileName.lowercased() {
+                    if self.isLoaded {
+                        self.closeInternal()
+                    }
                 }
                 promise.resolve()
             } catch {
@@ -405,6 +414,7 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
     private func closeInternal() {
         isLoaded = false
         history.removeAll()
+        loadedModelPath = nil
         
         if let conversation = self.conversation {
             litert_lm_conversation_delete(conversation)
@@ -425,7 +435,7 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
         )
     }
     
-    // MARK: - String and JSON Preprocessing Helpers
+    // MARK: - Internal Preprocessing Helpers (for extension files)
     
     private let kControlTokens = [
         "<end_of_turn>",

--- a/ios/HybridLiteRTLM.swift
+++ b/ios/HybridLiteRTLM.swift
@@ -218,7 +218,7 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
             rawEngine = createEngine(mainBackendStr, visionBackend, audioBackend)
             
             // Fallback sequence if GPU/NPU fails to initialize
-            if rawEngine == nil && mainBackendStr != "cpu" {
+            if rawEngine == nil {
                 // Fallback 1: CPU execution with GPU acceleration for heavy Vision parameters
                 rawEngine = createEngine("cpu", "gpu", "cpu")
                 

--- a/ios/HybridLiteRTLM.swift
+++ b/ios/HybridLiteRTLM.swift
@@ -11,56 +11,25 @@ import NitroModules
 import CLiteRTLM
 import os
 
-/// A stream context passed to the low-level C FFI callback to forward chunks safely to the JS thread.
-private class StreamContext {
-    let userMessage: String
-    let historyUserContent: String
-    let startTime: Date
-    let onToken: (_ token: String, _ done: Bool) -> Void
-    let promise: Promise<Void>
-    let parent: HybridLiteRTLM
-    
-    var rawResponse: String = ""
-    var fullResponse: String = ""
-    var lastEmittedLength: Int = 0
-    var tokenCount: Int = 0
-    
-    init(
-        userMessage: String,
-        historyUserContent: String? = nil,
-        startTime: Date,
-        onToken: @escaping (_ token: String, _ done: Bool) -> Void,
-        promise: Promise<Void>,
-        parent: HybridLiteRTLM
-    ) {
-        self.userMessage = userMessage
-        self.historyUserContent = historyUserContent ?? userMessage
-        self.startTime = startTime
-        self.onToken = onToken
-        self.promise = promise
-        self.parent = parent
-    }
-}
-
 public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protocol {
     
     /// Dedicated background serial queue to protect the JSI/JS thread from blocking and deadlocks (User Rule #1).
-    private let queue = DispatchQueue(label: "dev.litert.engine", qos: .userInteractive)
+    let queue = DispatchQueue(label: "dev.litert.engine", qos: .userInteractive)
     
     /// Opaque pointer to the LiteRT LM C Engine.
     private var engine: OpaquePointer?
     
     /// Opaque pointer to the active conversation state.
-    private var conversation: OpaquePointer?
+    var conversation: OpaquePointer?
     
     /// Thread-safe status flag.
     private var isLoaded = false
     
     /// Conversation history.
-    private var history: [Message] = []
+    var history: [Message] = []
     
     /// Latest inference generation statistics.
-    private var lastStats = GenerationStats(
+    var lastStats = GenerationStats(
         promptTokens: 0.0,
         completionTokens: 0.0,
         totalTokens: 0.0,
@@ -74,7 +43,7 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
     private var temperature: Double = 0.7
     private var topK: Int = 40
     private var topP: Double = 0.95
-    private var maxTokens: Int = 1024
+    private var maxTokens: Int = 2048
     private var systemPrompt: String?
     private var tools: [ToolDefinition]?
     private var enableSpeculativeDecoding: Bool = false
@@ -289,741 +258,44 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
         return promise
     }
     
+    // Legacy inference — shapes mirror src/inferenceRouting.ts; JS createLLM routes via execute.
     public func sendMessage(message: String) throws -> Promise<String> {
-        let promise = Promise<String>()
-        
-        queue.async {
-            guard let conversation = self.conversation else {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 400, userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: No model loaded. Call loadModel() first."]))
-                return
-            }
-            
-            let msgJson = self.buildTextMessageJson(text: message)
-            let startTime = Date()
-            
-            // Synchronous FFI call blocks only this interactive queue
-            guard let response = litert_lm_conversation_send_message(conversation, msgJson, nil, nil) else {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 500, userInfo: [NSLocalizedDescriptionKey: "LiteRT-LM: sendMessage failed"]))
-                return
-            }
-            defer { litert_lm_json_response_delete(response) }
-            
-            var result = ""
-            if let responseStr = litert_lm_json_response_get_string(response) {
-                result = self.extractTextFromResponse(String(cString: responseStr))
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-            }
-            
-            let endTime = Date()
-            let totalTime = endTime.timeIntervalSince(startTime)
-            
-            var completionTokens = 0.0
-            var tokensPerSecond = 0.0
-            var ttft = 0.0
-            
-            if let benchInfo = litert_lm_conversation_get_benchmark_info(conversation) {
-                let numDecodeTurns = litert_lm_benchmark_info_get_num_decode_turns(benchInfo)
-                if numDecodeTurns > 0 {
-                    let lastIdx = numDecodeTurns - 1
-                    tokensPerSecond = litert_lm_benchmark_info_get_decode_tokens_per_sec_at(benchInfo, lastIdx)
-                    completionTokens = Double(litert_lm_benchmark_info_get_decode_token_count_at(benchInfo, lastIdx))
-                }
-                ttft = litert_lm_benchmark_info_get_time_to_first_token(benchInfo)
-                litert_lm_benchmark_info_delete(benchInfo)
-            }
-            
-            let promptTokens = Double(message.count) / 4.0
-            if completionTokens == 0.0 {
-                completionTokens = Double(result.count) / 4.0
-            }
-            
-            self.lastStats = GenerationStats(
-                promptTokens: promptTokens,
-                completionTokens: completionTokens,
-                totalTokens: promptTokens + completionTokens,
-                timeToFirstToken: ttft,
-                totalTime: totalTime,
-                tokensPerSecond: tokensPerSecond > 0.0 ? tokensPerSecond : (completionTokens / totalTime)
-            )
-            
-            self.history.append(Message(role: .user, content: message))
-            self.history.append(Message(role: .model, content: result))
-            
-            promise.resolve(withResult: result)
-        }
-        
-        return promise
+        try execute(parts: [.textPart(message)], onToken: nil)
     }
-    
+
     public func sendMessageAsync(
         message: String,
         onToken: @escaping (_ token: String, _ done: Bool) -> Void
     ) throws -> Promise<Void> {
-        let promise = Promise<Void>()
-        
-        queue.async {
-            guard let conversation = self.conversation else {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 400, userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: No model loaded. Call loadModel() first."]))
-                return
-            }
-            
-            let msgJson = self.buildTextMessageJson(text: message)
-            let startTime = Date()
-            
-            let context = StreamContext(
-                userMessage: message,
-                startTime: startTime,
-                onToken: onToken,
-                promise: promise,
-                parent: self
-            )
-            
-            let callbackData = Unmanaged.passRetained(context).toOpaque()
-            
-            let callback: LiteRtLmStreamCallback = { callbackData, chunk, isFinal, errorMsg in
-                guard let callbackData = callbackData else { return }
-                let ctx = Unmanaged<StreamContext>.fromOpaque(callbackData).takeUnretainedValue()
-                
-                if let errorMsg = errorMsg {
-                    let errorStr = String(cString: errorMsg)
-                    ctx.onToken("Error: \(errorStr)", true)
-                    ctx.promise.reject(withError: NSError(domain: "LiteRTLM", code: 500, userInfo: [NSLocalizedDescriptionKey: errorStr]))
-                    Unmanaged<StreamContext>.fromOpaque(callbackData).release()
-                    return
-                }
-                
-                if isFinal {
-                    let endTime = Date()
-                    let totalTime = endTime.timeIntervalSince(ctx.startTime)
-                    
-                    let cleaned = ctx.parent.stripControlTokens(ctx.rawResponse)
-                    var finalCleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !ctx.userMessage.isEmpty && finalCleaned.hasPrefix(ctx.userMessage) {
-                        finalCleaned = String(finalCleaned.dropFirst(ctx.userMessage.count))
-                            .trimmingCharacters(in: .whitespacesAndNewlines)
-                    }
-                    
-                    if finalCleaned.count > ctx.lastEmittedLength {
-                        let startIdx = finalCleaned.index(finalCleaned.startIndex, offsetBy: ctx.lastEmittedLength)
-                        let remaining = String(finalCleaned[startIdx...])
-                        ctx.onToken(remaining, false)
-                    }
-                    ctx.fullResponse = finalCleaned
-
-                    // This callback fires on an engine-internal thread (the C API
-                    // returns once the stream *starts*), so commit the shared
-                    // lastStats/history — and the conversation benchmark read — on
-                    // the serial engine queue to avoid racing getStats()/getHistory().
-                    // Resolving inside the same block guarantees JS observes the
-                    // final turn before the promise settles.
-                    ctx.parent.queue.async {
-                        var completionTokens = Double(ctx.tokenCount)
-                        var tokensPerSecond = 0.0
-                        var ttft = 0.0
-
-                        if let benchInfo = litert_lm_conversation_get_benchmark_info(ctx.parent.conversation) {
-                            let numDecodeTurns = litert_lm_benchmark_info_get_num_decode_turns(benchInfo)
-                            if numDecodeTurns > 0 {
-                                let lastIdx = numDecodeTurns - 1
-                                tokensPerSecond = litert_lm_benchmark_info_get_decode_tokens_per_sec_at(benchInfo, lastIdx)
-                                completionTokens = Double(litert_lm_benchmark_info_get_decode_token_count_at(benchInfo, lastIdx))
-                            }
-                            ttft = litert_lm_benchmark_info_get_time_to_first_token(benchInfo)
-                            litert_lm_benchmark_info_delete(benchInfo)
-                        }
-
-                        let promptTokens = Double(ctx.userMessage.count) / 4.0
-                        if completionTokens == 0.0 {
-                            completionTokens = Double(ctx.fullResponse.count) / 4.0
-                        }
-
-                        ctx.parent.lastStats = GenerationStats(
-                            promptTokens: promptTokens,
-                            completionTokens: completionTokens,
-                            totalTokens: promptTokens + completionTokens,
-                            timeToFirstToken: ttft,
-                            totalTime: totalTime,
-                            tokensPerSecond: tokensPerSecond > 0.0 ? tokensPerSecond : (completionTokens / totalTime)
-                        )
-
-                        ctx.parent.history.append(Message(role: .user, content: ctx.userMessage))
-                        ctx.parent.history.append(Message(role: .model, content: ctx.fullResponse))
-
-                        ctx.onToken("", true)
-                        ctx.promise.resolve()
-                        Unmanaged<StreamContext>.fromOpaque(callbackData).release()
-                    }
-                    return
-                }
-                
-                if let chunk = chunk {
-                    let token = String(cString: chunk)
-                    let raw: String
-                    if token.hasPrefix("{") && token.contains("\"role\"") {
-                        raw = ctx.parent.extractTextFromResponse(token)
-                    } else {
-                        raw = token
-                    }
-                    
-                    ctx.rawResponse += raw
-                    let cleaned = ctx.parent.stripControlTokens(ctx.rawResponse)
-                        .trimmingLeadingCharacters(in: .whitespacesAndNewlines)
-                    
-                    var processed = cleaned
-                    if !ctx.userMessage.isEmpty && processed.hasPrefix(ctx.userMessage) {
-                        processed = String(processed.dropFirst(ctx.userMessage.count))
-                            .trimmingLeadingCharacters(in: .whitespacesAndNewlines)
-                    }
-                    
-                    let safeLen = ctx.parent.safeEmitLength(processed)
-                    if safeLen > ctx.lastEmittedLength {
-                        let chars = Array(processed)
-                        let newText = String(chars[ctx.lastEmittedLength..<safeLen])
-                        ctx.lastEmittedLength = safeLen
-                        ctx.tokenCount += 1
-                        ctx.onToken(newText, false)
-                    }
-                }
-            }
-            
-            let status = litert_lm_conversation_send_message_stream(
-                conversation,
-                msgJson,
-                nil,
-                nil,
-                callback,
-                callbackData
-            )
-            
-            if status != 0 {
-                Unmanaged<StreamContext>.fromOpaque(callbackData).release()
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: Int(status), userInfo: [NSLocalizedDescriptionKey: "Failed to start streaming conversation."]))
-            }
-        }
-        
-        return promise
+        try executeVoid(parts: [.textPart(message)], onToken: onToken)
     }
-    
+
     public func sendMessageWithImage(message: String, imagePath: String) throws -> Promise<String> {
-        let promise = Promise<String>()
-        
-        queue.async {
-            guard let conversation = self.conversation else {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 400, userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: No model loaded. Call loadModel() first."]))
-                return
-            }
-            
-            if !FileManager.default.fileExists(atPath: imagePath) {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 404, userInfo: [NSLocalizedDescriptionKey: "Image file not found: \(imagePath)"]))
-                return
-            }
-            
-            let msgJson = self.buildImageMessageJson(text: message, imagePath: imagePath)
-            let startTime = Date()
-            
-            guard let response = litert_lm_conversation_send_message(conversation, msgJson, nil, nil) else {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 500, userInfo: [NSLocalizedDescriptionKey: "LiteRT-LM: sendMessageWithImage failed"]))
-                return
-            }
-            defer { litert_lm_json_response_delete(response) }
-            
-            var result = ""
-            if let responseStr = litert_lm_json_response_get_string(response) {
-                result = self.extractTextFromResponse(String(cString: responseStr))
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-            }
-            
-            let endTime = Date()
-            let totalTime = endTime.timeIntervalSince(startTime)
-            
-            self.lastStats = GenerationStats(
-                promptTokens: Double(message.count) / 4.0,
-                completionTokens: Double(result.count) / 4.0,
-                totalTokens: Double(message.count + result.count) / 4.0,
-                timeToFirstToken: 0.0,
-                totalTime: totalTime,
-                tokensPerSecond: Double(result.count) / 4.0 / totalTime
-            )
-            
-            self.history.append(Message(role: .user, content: message + " [image: \(imagePath)]"))
-            self.history.append(Message(role: .model, content: result))
-            
-            promise.resolve(withResult: result)
-        }
-        
-        return promise
+        try execute(parts: [.textPart(message), .imagePart(imagePath)], onToken: nil)
     }
 
-    public func sendMessageWithImageAsync(message: String, imagePath: String, onToken: @escaping (_ token: String, _ done: Bool) -> Void) throws -> Promise<Void> {
-        let promise = Promise<Void>()
-        
-        queue.async {
-            guard let conversation = self.conversation else {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 400, userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: No model loaded. Call loadModel() first."]))
-                return
-            }
-            
-            if !FileManager.default.fileExists(atPath: imagePath) {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 404, userInfo: [NSLocalizedDescriptionKey: "Image file not found: \(imagePath)"]))
-                return
-            }
-            
-            let msgJson = self.buildImageMessageJson(text: message, imagePath: imagePath)
-            let startTime = Date()
-            
-            let historyUserContent = message + " [image: \(imagePath)]"
-            let context = StreamContext(
-                userMessage: message,
-                historyUserContent: historyUserContent,
-                startTime: startTime,
-                onToken: onToken,
-                promise: promise,
-                parent: self
-            )
-            
-            let callbackData = Unmanaged.passRetained(context).toOpaque()
-            
-            let callback: LiteRtLmStreamCallback = { callbackData, chunk, isFinal, errorMsg in
-                guard let callbackData = callbackData else { return }
-                let ctx = Unmanaged<StreamContext>.fromOpaque(callbackData).takeUnretainedValue()
-                
-                if let errorMsg = errorMsg {
-                    let errorStr = String(cString: errorMsg)
-                    ctx.onToken("Error: \(errorStr)", true)
-                    ctx.promise.reject(withError: NSError(domain: "LiteRTLM", code: 500, userInfo: [NSLocalizedDescriptionKey: errorStr]))
-                    Unmanaged<StreamContext>.fromOpaque(callbackData).release()
-                    return
-                }
-                
-                if isFinal {
-                    let endTime = Date()
-                    let totalTime = endTime.timeIntervalSince(ctx.startTime)
-                    
-                    let cleaned = ctx.parent.stripControlTokens(ctx.rawResponse)
-                    var finalCleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !ctx.userMessage.isEmpty && finalCleaned.hasPrefix(ctx.userMessage) {
-                        finalCleaned = String(finalCleaned.dropFirst(ctx.userMessage.count))
-                            .trimmingCharacters(in: .whitespacesAndNewlines)
-                    }
-                    
-                    if finalCleaned.count > ctx.lastEmittedLength {
-                        let startIdx = finalCleaned.index(finalCleaned.startIndex, offsetBy: ctx.lastEmittedLength)
-                        let remaining = String(finalCleaned[startIdx...])
-                        ctx.onToken(remaining, false)
-                    }
-                    ctx.fullResponse = finalCleaned
-                    
-                    ctx.parent.queue.async {
-                        var completionTokens = Double(ctx.tokenCount)
-                        var tokensPerSecond = 0.0
-                        var ttft = 0.0
-                        if let benchInfo = litert_lm_conversation_get_benchmark_info(ctx.parent.conversation) {
-                            let numDecodeTurns = litert_lm_benchmark_info_get_num_decode_turns(benchInfo)
-                            if numDecodeTurns > 0 {
-                                let lastIdx = numDecodeTurns - 1
-                                tokensPerSecond = litert_lm_benchmark_info_get_decode_tokens_per_sec_at(benchInfo, lastIdx)
-                                completionTokens = Double(litert_lm_benchmark_info_get_decode_token_count_at(benchInfo, lastIdx))
-                            }
-                            ttft = litert_lm_benchmark_info_get_time_to_first_token(benchInfo)
-                            litert_lm_benchmark_info_delete(benchInfo)
-                        }
-
-                        let promptTokens = Double(ctx.userMessage.count) / 4.0
-                        if completionTokens == 0.0 {
-                            completionTokens = Double(ctx.fullResponse.count) / 4.0
-                        }
-                        ctx.parent.lastStats = GenerationStats(
-                            promptTokens: promptTokens,
-                            completionTokens: completionTokens,
-                            totalTokens: promptTokens + completionTokens,
-                            timeToFirstToken: ttft,
-                            totalTime: totalTime,
-                            tokensPerSecond: tokensPerSecond > 0.0 ? tokensPerSecond : (completionTokens / totalTime)
-                        )
-                        ctx.parent.history.append(Message(role: .user, content: ctx.historyUserContent))
-                        ctx.parent.history.append(Message(role: .model, content: ctx.fullResponse))
-                        ctx.onToken("", true)
-                        ctx.promise.resolve()
-                        Unmanaged<StreamContext>.fromOpaque(callbackData).release()
-                    }
-                    return
-                }
-
-                if let chunk = chunk {
-                    let token = String(cString: chunk)
-                    let raw: String
-                    if token.hasPrefix("{") && token.contains("\"role\"") {
-                        raw = ctx.parent.extractTextFromResponse(token)
-                    } else {
-                        raw = token
-                    }
-
-                    ctx.rawResponse += raw
-                    let cleaned = ctx.parent.stripControlTokens(ctx.rawResponse)
-                        .trimmingLeadingCharacters(in: .whitespacesAndNewlines)
-
-                    var processed = cleaned
-                    if !ctx.userMessage.isEmpty && processed.hasPrefix(ctx.userMessage) {
-                        processed = String(processed.dropFirst(ctx.userMessage.count))
-                            .trimmingLeadingCharacters(in: .whitespacesAndNewlines)
-                    }
-
-                    let safeLen = ctx.parent.safeEmitLength(processed)
-                    if safeLen > ctx.lastEmittedLength {
-                        let chars = Array(processed)
-                        let newText = String(chars[ctx.lastEmittedLength..<safeLen])
-                        ctx.lastEmittedLength = safeLen
-                        ctx.tokenCount += 1
-                        ctx.onToken(newText, false)
-                    }
-                }
-            }
-
-            let status = litert_lm_conversation_send_message_stream(
-                conversation,
-                msgJson,
-                nil,
-                nil,
-                callback,
-                callbackData
-            )
-            if status != 0 {
-                Unmanaged<StreamContext>.fromOpaque(callbackData).release()
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: Int(status), userInfo: [NSLocalizedDescriptionKey: "Failed to start streaming conversation."]))
-            }
-        }
-
-        return promise
+    public func sendMessageWithImageAsync(
+        message: String, imagePath: String,
+        onToken: @escaping (_ token: String, _ done: Bool) -> Void
+    ) throws -> Promise<Void> {
+        try executeVoid(parts: [.textPart(message), .imagePart(imagePath)], onToken: onToken)
     }
-    
-    public func sendMessageWithAudioAsync(message: String, audioPath: String, onToken: @escaping (_ token: String, _ done: Bool) -> Void) throws -> Promise<Void> {
-        let promise = Promise<Void>()
 
-        queue.async {
-            guard let conversation = self.conversation else {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 400, userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: No model loaded. Call loadModel() first."]))
-                return
-            }
-
-            if !FileManager.default.fileExists(atPath: audioPath) {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 404, userInfo: [NSLocalizedDescriptionKey: "Audio file not found: \(audioPath)"]))
-                return
-            }
-
-            let msgJson = self.buildAudioMessageJson(text: message, audioPath: audioPath)
-            let startTime = Date()
-
-            let historyUserContent = message + " [audio: \(audioPath)]"
-            let context = StreamContext(
-                userMessage: message,
-                historyUserContent: historyUserContent,
-                startTime: startTime,
-                onToken: onToken,
-                promise: promise,
-                parent: self
-            )
-
-            let callbackData = Unmanaged.passRetained(context).toOpaque()
-
-            let callback: LiteRtLmStreamCallback = { callbackData, chunk, isFinal, errorMsg in
-                guard let callbackData = callbackData else { return }
-                let ctx = Unmanaged<StreamContext>.fromOpaque(callbackData).takeUnretainedValue()
-
-                if let errorMsg = errorMsg {
-                    let errorStr = String(cString: errorMsg)
-                    ctx.onToken("Error: \(errorStr)", true)
-                    ctx.promise.reject(withError: NSError(domain: "LiteRTLM", code: 500, userInfo: [NSLocalizedDescriptionKey: errorStr]))
-                    Unmanaged<StreamContext>.fromOpaque(callbackData).release()
-                    return
-                }
-
-                if isFinal {
-                    let endTime = Date()
-                    let totalTime = endTime.timeIntervalSince(ctx.startTime)
-
-                    let cleaned = ctx.parent.stripControlTokens(ctx.rawResponse)
-                    var finalCleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !ctx.userMessage.isEmpty && finalCleaned.hasPrefix(ctx.userMessage) {
-                        finalCleaned = String(finalCleaned.dropFirst(ctx.userMessage.count))
-                            .trimmingCharacters(in: .whitespacesAndNewlines)
-                    }
-
-                    if finalCleaned.count > ctx.lastEmittedLength {
-                        let startIdx = finalCleaned.index(finalCleaned.startIndex, offsetBy: ctx.lastEmittedLength)
-                        let remaining = String(finalCleaned[startIdx...])
-                        ctx.onToken(remaining, false)
-                    }
-                    ctx.fullResponse = finalCleaned
-
-                    ctx.parent.queue.async {
-                        var completionTokens = Double(ctx.tokenCount)
-                        var tokensPerSecond = 0.0
-                        var ttft = 0.0
-                        if let benchInfo = litert_lm_conversation_get_benchmark_info(ctx.parent.conversation) {
-                            let numDecodeTurns = litert_lm_benchmark_info_get_num_decode_turns(benchInfo)
-                            if numDecodeTurns > 0 {
-                                let lastIdx = numDecodeTurns - 1
-                                tokensPerSecond = litert_lm_benchmark_info_get_decode_tokens_per_sec_at(benchInfo, lastIdx)
-                                completionTokens = Double(litert_lm_benchmark_info_get_decode_token_count_at(benchInfo, lastIdx))
-                            }
-                            ttft = litert_lm_benchmark_info_get_time_to_first_token(benchInfo)
-                            litert_lm_benchmark_info_delete(benchInfo)
-                        }
-
-                        let promptTokens = Double(ctx.userMessage.count) / 4.0
-                        if completionTokens == 0.0 {
-                            completionTokens = Double(ctx.fullResponse.count) / 4.0
-                        }
-                        ctx.parent.lastStats = GenerationStats(
-                            promptTokens: promptTokens,
-                            completionTokens: completionTokens,
-                            totalTokens: promptTokens + completionTokens,
-                            timeToFirstToken: ttft,
-                            totalTime: totalTime,
-                            tokensPerSecond: tokensPerSecond > 0.0 ? tokensPerSecond : (completionTokens / totalTime)
-                        )
-                        ctx.parent.history.append(Message(role: .user, content: ctx.historyUserContent))
-                        ctx.parent.history.append(Message(role: .model, content: ctx.fullResponse))
-                        ctx.onToken("", true)
-                        ctx.promise.resolve()
-                        Unmanaged<StreamContext>.fromOpaque(callbackData).release()
-                    }
-                    return
-                }
-
-                if let chunk = chunk {
-                    let token = String(cString: chunk)
-                    let raw: String
-                    if token.hasPrefix("{") && token.contains("\"role\"") {
-                        raw = ctx.parent.extractTextFromResponse(token)
-                    } else {
-                        raw = token
-                    }
-
-                    ctx.rawResponse += raw
-                    let cleaned = ctx.parent.stripControlTokens(ctx.rawResponse)
-                        .trimmingLeadingCharacters(in: .whitespacesAndNewlines)
-
-                    var processed = cleaned
-                    if !ctx.userMessage.isEmpty && processed.hasPrefix(ctx.userMessage) {
-                        processed = String(processed.dropFirst(ctx.userMessage.count))
-                            .trimmingLeadingCharacters(in: .whitespacesAndNewlines)
-                    }
-
-                    let safeLen = ctx.parent.safeEmitLength(processed)
-                    if safeLen > ctx.lastEmittedLength {
-                        let chars = Array(processed)
-                        let newText = String(chars[ctx.lastEmittedLength..<safeLen])
-                        ctx.lastEmittedLength = safeLen
-                        ctx.tokenCount += 1
-                        ctx.onToken(newText, false)
-                    }
-                }
-            }
-
-            let status = litert_lm_conversation_send_message_stream(
-                conversation,
-                msgJson,
-                nil,
-                nil,
-                callback,
-                callbackData
-            )
-            if status != 0 {
-                Unmanaged<StreamContext>.fromOpaque(callbackData).release()
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: Int(status), userInfo: [NSLocalizedDescriptionKey: "Failed to start streaming conversation."]))
-            }
-        }
-
-        return promise
+    public func sendMessageWithAudioAsync(
+        message: String, audioPath: String,
+        onToken: @escaping (_ token: String, _ done: Bool) -> Void
+    ) throws -> Promise<Void> {
+        try executeVoid(parts: [.textPart(message), .audioPart(audioPath)], onToken: onToken)
     }
 
     public func sendMessageWithAudio(message: String, audioPath: String) throws -> Promise<String> {
-        let promise = Promise<String>()
-        
-        queue.async {
-            guard let conversation = self.conversation else {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 400, userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: No model loaded. Call loadModel() first."]))
-                return
-            }
-            
-            if !FileManager.default.fileExists(atPath: audioPath) {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 404, userInfo: [NSLocalizedDescriptionKey: "Audio file not found: \(audioPath)"]))
-                return
-            }
-            
-            let msgJson = self.buildAudioMessageJson(text: message, audioPath: audioPath)
-            let startTime = Date()
-            
-            guard let response = litert_lm_conversation_send_message(conversation, msgJson, nil, nil) else {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 500, userInfo: [NSLocalizedDescriptionKey: "LiteRT-LM: sendMessageWithAudio failed"]))
-                return
-            }
-            defer { litert_lm_json_response_delete(response) }
-            
-            var result = ""
-            if let responseStr = litert_lm_json_response_get_string(response) {
-                result = self.extractTextFromResponse(String(cString: responseStr))
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-            }
-            
-            let endTime = Date()
-            let totalTime = endTime.timeIntervalSince(startTime)
-            
-            self.lastStats = GenerationStats(
-                promptTokens: Double(message.count) / 4.0,
-                completionTokens: Double(result.count) / 4.0,
-                totalTokens: Double(message.count + result.count) / 4.0,
-                timeToFirstToken: 0.0,
-                totalTime: totalTime,
-                tokensPerSecond: Double(result.count) / 4.0 / totalTime
-            )
-            
-            self.history.append(Message(role: .user, content: message + " [audio: \(audioPath)]"))
-            self.history.append(Message(role: .model, content: result))
-            
-            promise.resolve(withResult: result)
-        }
-        
-        return promise
+        try execute(parts: [.textPart(message), .audioPart(audioPath)], onToken: nil)
     }
-    
+
     public func sendMultimodalMessage(parts: [MultimodalPart]) throws -> Promise<String> {
-        let promise = Promise<String>()
-        
-        queue.async {
-            guard let engine = self.engine else {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 400, userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: No model loaded. Call loadModel() first."]))
-                return
-            }
-            
-            // Create session config
-            guard let sessionConfig = litert_lm_session_config_create() else {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 500, userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: Failed to create session config."]))
-                return
-            }
-            defer { litert_lm_session_config_delete(sessionConfig) }
-            
-            litert_lm_session_config_set_max_output_tokens(sessionConfig, Int32(self.maxTokens))
-            
-            var sampler = LiteRtLmSamplerParams()
-            sampler.type = kLiteRtLmSamplerTypeTopP
-            sampler.top_k = Int32(self.topK)
-            sampler.top_p = Float(self.topP)
-            sampler.temperature = Float(self.temperature)
-            sampler.seed = 0
-            withUnsafePointer(to: &sampler) { samplerPtr in
-                litert_lm_session_config_set_sampler_params(sessionConfig, samplerPtr)
-            }
-            
-            guard let session = litert_lm_engine_create_session(engine, sessionConfig) else {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 500, userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: Failed to create session."]))
-                return
-            }
-            defer { litert_lm_session_delete(session) }
-            
-            // Construct inputs array
-            var inputs: [LiteRtLmInputData] = []
-            var allocatedStrings: [UnsafeMutablePointer<CChar>] = []
-            
-            defer {
-                for ptr in allocatedStrings {
-                    free(ptr)
-                }
-            }
-            
-            for part in parts {
-                switch part.type {
-                case .text:
-                    if let text = part.text {
-                        let cStr = strdup(text)!
-                        allocatedStrings.append(cStr)
-                        inputs.append(LiteRtLmInputData(type: kLiteRtLmInputDataTypeText, data: cStr, size: text.utf8.count))
-                    }
-                case .image:
-                    if let imageBuffer = part.imageBuffer {
-                        inputs.append(LiteRtLmInputData(type: kLiteRtLmInputDataTypeImage, data: imageBuffer.data, size: imageBuffer.size))
-                    }
-                case .audio:
-                    if let audioBuffer = part.audioBuffer {
-                        inputs.append(LiteRtLmInputData(type: kLiteRtLmInputDataTypeAudio, data: audioBuffer.data, size: audioBuffer.size))
-                    }
-                }
-            }
-            
-            let startTime = Date()
-            
-            // Run session inference
-            guard let responses = litert_lm_session_generate_content(session, inputs, inputs.count) else {
-                promise.reject(withError: NSError(domain: "LiteRTLM", code: 500, userInfo: [NSLocalizedDescriptionKey: "LiteRTLM: Session generate content failed."]))
-                return
-            }
-            defer { litert_lm_responses_delete(responses) }
-            
-            var result = ""
-            let numCandidates = litert_lm_responses_get_num_candidates(responses)
-            if numCandidates > 0 {
-                if let responseStr = litert_lm_responses_get_response_text_at(responses, 0) {
-                    result = String(cString: responseStr).trimmingCharacters(in: .whitespacesAndNewlines)
-                }
-            }
-            
-            let endTime = Date()
-            let totalTime = endTime.timeIntervalSince(startTime)
-            
-            // Update last stats using benchmark info from session
-            var completionTokens = 0.0
-            var tokensPerSecond = 0.0
-            var ttft = 0.0
-            
-            if let benchInfo = litert_lm_session_get_benchmark_info(session) {
-                let numDecodeTurns = litert_lm_benchmark_info_get_num_decode_turns(benchInfo)
-                if numDecodeTurns > 0 {
-                    let lastIdx = numDecodeTurns - 1
-                    tokensPerSecond = litert_lm_benchmark_info_get_decode_tokens_per_sec_at(benchInfo, lastIdx)
-                    completionTokens = Double(litert_lm_benchmark_info_get_decode_token_count_at(benchInfo, lastIdx))
-                }
-                ttft = litert_lm_benchmark_info_get_time_to_first_token(benchInfo)
-                litert_lm_benchmark_info_delete(benchInfo)
-            }
-            
-            let totalInputLen = parts.reduce(0) { $0 + ($1.text?.count ?? 0) }
-            let promptTokens = Double(totalInputLen) / 4.0
-            if completionTokens == 0.0 {
-                completionTokens = Double(result.count) / 4.0
-            }
-            
-            self.lastStats = GenerationStats(
-                promptTokens: promptTokens,
-                completionTokens: completionTokens,
-                totalTokens: promptTokens + completionTokens,
-                timeToFirstToken: ttft,
-                totalTime: totalTime,
-                tokensPerSecond: tokensPerSecond > 0.0 ? tokensPerSecond : (completionTokens / totalTime)
-            )
-            
-            // Append to history
-            var userTextRepresentation = ""
-            for part in parts {
-                if part.type == .text, let text = part.text {
-                    userTextRepresentation += text + " "
-                } else if part.type == .image {
-                    userTextRepresentation += "[Image Buffer] "
-                } else if part.type == .audio {
-                    userTextRepresentation += "[Audio Buffer] "
-                }
-            }
-            userTextRepresentation = userTextRepresentation.trimmingCharacters(in: .whitespacesAndNewlines)
-            
-            self.history.append(Message(role: .user, content: userTextRepresentation))
-            self.history.append(Message(role: .model, content: result))
-            
-            promise.resolve(withResult: result)
-        }
-        
-        return promise
+        try execute(parts: parts, onToken: nil)
     }
-    
+
     public func downloadModel(
         url: String,
         fileName: String,
@@ -1150,7 +422,7 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
         "<eos>"
     ]
     
-    private func escapeJson(_ input: String) -> String {
+    func escapeJson(_ input: String) -> String {
         var output = ""
         for char in input {
             switch char {
@@ -1167,25 +439,7 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
         return output
     }
     
-    private func buildTextMessageJson(text: String) -> String {
-        return "{\"role\":\"user\",\"content\":\"" + escapeJson(text) + "\"}"
-    }
-    
-    private func buildImageMessageJson(text: String, imagePath: String) -> String {
-        return "{\"role\":\"user\",\"content\":[" +
-               "{\"type\":\"text\",\"text\":\"" + escapeJson(text) + "\"}," +
-               "{\"type\":\"image\",\"path\":\"" + escapeJson(imagePath) + "\"}" +
-               "]}"
-    }
-    
-    private func buildAudioMessageJson(text: String, audioPath: String) -> String {
-        return "{\"role\":\"user\",\"content\":[" +
-               "{\"type\":\"text\",\"text\":\"" + escapeJson(text) + "\"}," +
-               "{\"type\":\"audio\",\"path\":\"" + escapeJson(audioPath) + "\"}" +
-               "]}"
-    }
-    
-    private func stripControlTokens(_ text: String) -> String {
+    func stripControlTokens(_ text: String) -> String {
         var result = text
         for tok in kControlTokens {
             result = result.replacingOccurrences(of: tok, with: "")
@@ -1193,7 +447,7 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
         return result
     }
     
-    private func safeEmitLength(_ text: String) -> Int {
+    func safeEmitLength(_ text: String) -> Int {
         let chars = Array(text)
         guard let lastAngleIdx = chars.lastIndex(of: "<") else {
             return chars.count
@@ -1207,7 +461,7 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
         return chars.count
     }
     
-    private func extractTextFromResponse(_ jsonResponse: String) -> String {
+    func extractTextFromResponse(_ jsonResponse: String) -> String {
         guard let data = jsonResponse.data(using: .utf8) else {
             return stripControlTokens(jsonResponse)
         }
@@ -1238,17 +492,5 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
             return block(nil)
         }
     }
-}
 
-// MARK: - String Trimming Extension
-
-private extension String {
-    func trimmingLeadingCharacters(in characterSet: CharacterSet) -> String {
-        guard let index = firstIndex(where: { char in
-            !char.unicodeScalars.allSatisfy { characterSet.contains($0) }
-        }) else {
-            return ""
-        }
-        return String(self[index...])
-    }
 }

--- a/ios/HybridModelStore.swift
+++ b/ios/HybridModelStore.swift
@@ -1,0 +1,205 @@
+//
+//  HybridModelStore.swift
+//  react-native-litert-lm
+//
+//  Created by Antigravity on 2026-06-04.
+//  Copyright © 2026 Margelo. All rights reserved.
+//
+
+import Foundation
+import NitroModules
+
+public class HybridModelStore: HybridModelStoreSpec_base, HybridModelStoreSpec_protocol {
+    
+    private let queue = DispatchQueue(label: "dev.litert.modelstore", qos: .utility)
+    
+    private var modelsDirectory: String {
+        let cachesDir = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first ?? NSTemporaryDirectory()
+        return (cachesDir as NSString).appendingPathComponent("litert_models")
+    }
+    
+    private func sanitizeFileName(_ fileName: String) throws {
+        if fileName.contains("..") || fileName.contains("/") || fileName.contains("\\") {
+            throw NSError(
+                domain: "LiteRTLM.ModelStore",
+                code: 400,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid filename: path traversal or directory separators are not allowed."]
+            )
+        }
+    }
+    
+    public func isCached(fileName: String) throws -> Bool {
+        try sanitizeFileName(fileName)
+        let filePath = (modelsDirectory as NSString).appendingPathComponent(fileName)
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: filePath) {
+            let attrs = try? fileManager.attributesOfItem(atPath: filePath)
+            if let fileSize = attrs?[.size] as? UInt64, fileSize > 0 {
+                return true
+            }
+        }
+        return false
+    }
+    
+    public func getFilePath(fileName: String) throws -> String {
+        try sanitizeFileName(fileName)
+        return (modelsDirectory as NSString).appendingPathComponent(fileName)
+    }
+    
+    public func listCachedFiles() throws -> [ModelFile] {
+        let fileManager = FileManager.default
+        let dir = modelsDirectory
+        
+        guard fileManager.fileExists(atPath: dir) else {
+            return []
+        }
+        
+        let contents = try fileManager.contentsOfDirectory(atPath: dir)
+        var files: [ModelFile] = []
+        
+        for name in contents {
+            let path = (dir as NSString).appendingPathComponent(name)
+            var isDir: ObjCBool = false
+            if fileManager.fileExists(atPath: path, isDirectory: &isDir), !isDir.boolValue {
+                let attrs = try? fileManager.attributesOfItem(atPath: path)
+                let size = (attrs?[.size] as? UInt64) ?? 0
+                let modDate = (attrs?[.modificationDate] as? Date) ?? Date()
+                
+                files.append(ModelFile(
+                    fileName: name,
+                    absolutePath: path,
+                    sizeBytes: Double(size),
+                    lastModifiedMs: modDate.timeIntervalSince1970 * 1000.0
+                ))
+            }
+        }
+        return files
+    }
+    
+    public func deleteFile(fileName: String) throws {
+        try sanitizeFileName(fileName)
+        let filePath = (modelsDirectory as NSString).appendingPathComponent(fileName)
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: filePath) {
+            try fileManager.removeItem(atPath: filePath)
+        }
+    }
+    
+    public func downloadFile(
+        url: String,
+        fileName: String,
+        headersJson: String,
+        onProgress: @escaping (_ progress: Double) -> Void
+    ) throws -> Promise<String> {
+        let promise = Promise<String>()
+        
+        queue.async {
+            do {
+                try self.sanitizeFileName(fileName)
+                let destPath = (self.modelsDirectory as NSString).appendingPathComponent(fileName)
+                let fileManager = FileManager.default
+                
+                if !fileManager.fileExists(atPath: self.modelsDirectory) {
+                    try fileManager.createDirectory(atPath: self.modelsDirectory, withIntermediateDirectories: true, attributes: nil)
+                }
+                
+                // Fast cache check
+                if fileManager.fileExists(atPath: destPath) {
+                    let attrs = try fileManager.attributesOfItem(atPath: destPath)
+                    if let fileSize = attrs[.size] as? UInt64, fileSize > 0 {
+                        onProgress(1.0)
+                        promise.resolve(withResult: destPath)
+                        return
+                    }
+                }
+                
+                guard let downloadUrl = URL(string: url), downloadUrl.scheme?.lowercased() == "https" else {
+                    promise.reject(withError: NSError(domain: "LiteRTLM.ModelStore", code: 400, userInfo: [NSLocalizedDescriptionKey: "Invalid download URL: HTTPS is required for security."]))
+                    return
+                }
+                
+                onProgress(0.0)
+                
+                // Parse headers JSON
+                var customHeaders: [String: String] = [:]
+                if !headersJson.isEmpty {
+                    if let data = headersJson.data(using: .utf8),
+                       let parsed = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: String] {
+                        customHeaders = parsed
+                    }
+                }
+                
+                let sessionConfig = URLSessionConfiguration.default
+                sessionConfig.timeoutIntervalForRequest = 30
+                sessionConfig.timeoutIntervalForResource = 3600
+                
+                let session = URLSession(configuration: sessionConfig)
+                var progressHandler: NSKeyValueObservation?
+                
+                var request = URLRequest(url: downloadUrl)
+                for (key, value) in customHeaders {
+                    request.addValue(value, forHTTPHeaderField: key)
+                }
+                
+                let tempDestFile = (self.modelsDirectory as NSString).appendingPathComponent("\(fileName).tmp")
+                
+                let task = session.downloadTask(with: request) { location, response, error in
+                    progressHandler?.invalidate()
+                    
+                    if let error = error {
+                        promise.reject(withError: error)
+                        return
+                    }
+                    
+                    if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode >= 400 {
+                        promise.reject(withError: NSError(domain: "LiteRTLM.ModelStore", code: httpResponse.statusCode, userInfo: [NSLocalizedDescriptionKey: "HTTP \(httpResponse.statusCode)"]))
+                        return
+                    }
+                    
+                    guard let location = location else {
+                        promise.reject(withError: NSError(domain: "LiteRTLM.ModelStore", code: 500, userInfo: [NSLocalizedDescriptionKey: "No download location found."]))
+                        return
+                    }
+                    
+                    do {
+                        // Rename/move atomically via temp file helper
+                        if fileManager.fileExists(atPath: tempDestFile) {
+                            try fileManager.removeItem(atPath: tempDestFile)
+                        }
+                        try fileManager.moveItem(at: location, to: URL(fileURLWithPath: tempDestFile))
+                        
+                        if fileManager.fileExists(atPath: destPath) {
+                            try fileManager.removeItem(atPath: destPath)
+                        }
+                        try fileManager.moveItem(at: URL(fileURLWithPath: tempDestFile), to: URL(fileURLWithPath: destPath))
+                        
+                        onProgress(1.0)
+                        promise.resolve(withResult: destPath)
+                    } catch {
+                        promise.reject(withError: error)
+                    }
+                }
+                
+                var lastUpdate = Date()
+                progressHandler = task.observe(\.countOfBytesReceived, options: [.new]) { task, _ in
+                    let expected = task.countOfBytesExpectedToReceive
+                    if expected > 0 {
+                        let now = Date()
+                        if now.timeIntervalSince(lastUpdate) > 0.1 {
+                            let progress = Double(task.countOfBytesReceived) / Double(expected)
+                            onProgress(progress)
+                            lastUpdate = now
+                        }
+                    }
+                }
+                
+                task.resume()
+                session.finishTasksAndInvalidate()
+            } catch {
+                promise.reject(withError: error)
+            }
+        }
+        
+        return promise
+    }
+}

--- a/ios/MultimodalPart+Factories.swift
+++ b/ios/MultimodalPart+Factories.swift
@@ -1,0 +1,22 @@
+//
+//  MultimodalPart+Factories.swift
+//  react-native-litert-lm
+//
+//  Mirrors src/inferenceRouting.ts — keep shapes in sync for native direct hybrid access.
+//
+
+import NitroModules
+
+extension MultimodalPart {
+    static func textPart(_ text: String) -> MultimodalPart {
+        MultimodalPart(type: .text, text: text, path: nil, imageBuffer: nil, audioBuffer: nil)
+    }
+
+    static func imagePart(_ path: String) -> MultimodalPart {
+        MultimodalPart(type: .image, text: nil, path: path, imageBuffer: nil, audioBuffer: nil)
+    }
+
+    static func audioPart(_ path: String) -> MultimodalPart {
+        MultimodalPart(type: .audio, text: nil, path: path, imageBuffer: nil, audioBuffer: nil)
+    }
+}

--- a/ios/Tests/HybridLiteRTLMTests.swift
+++ b/ios/Tests/HybridLiteRTLMTests.swift
@@ -122,4 +122,66 @@ class HybridLiteRTLMTests: XCTestCase {
             XCTAssertEqual(stats.tokensPerSecond, 0.0)
         }
     }
+
+    func testDeleteModelCleanupLogic() async throws {
+        bridge.loadedModelPath = "/path/to/my_loaded_model.litertlm"
+
+        let promise1 = try bridge.deleteModel(fileName: "other_model.litertlm")
+        _ = try await promise1.await()
+        XCTAssertEqual(bridge.loadedModelPath, "/path/to/my_loaded_model.litertlm")
+
+        let promise2 = try bridge.deleteModel(fileName: "my_loaded_model.litertlm")
+        _ = try await promise2.await()
+        XCTAssertNil(bridge.loadedModelPath)
+    }
+
+    func testExecutePathPrecedenceOverBuffer() async throws {
+        let pathPart = MultimodalPart(
+            type: .image,
+            text: nil,
+            path: "/nonexistent/precedence_test_image.jpg",
+            imageBuffer: nil,
+            audioBuffer: nil
+        )
+        
+        do {
+            let promise = try bridge.execute(parts: [pathPart], onToken: nil)
+            _ = try await promise.await()
+            XCTFail("Should have failed")
+        } catch {
+            let nsError = error as NSError
+            XCTAssertTrue(nsError.localizedDescription.contains("file not found: /nonexistent/precedence_test_image.jpg"))
+        }
+    }
+
+    func testExecuteTempFileCleanupOnError() async throws {
+        let dummyData = Data([0, 1, 2, 3])
+        let buffer = ArrayBuffer(dummyData)
+        
+        let bufferPart = MultimodalPart(
+            type: .image,
+            text: nil,
+            path: nil,
+            imageBuffer: buffer,
+            audioBuffer: nil
+        )
+        
+        let invalidPathPart = MultimodalPart(
+            type: .image,
+            text: nil,
+            path: "/nonexistent/invalid_file_cleanup_test.jpg",
+            imageBuffer: nil,
+            audioBuffer: nil
+        )
+        
+        do {
+            let promise = try bridge.execute(parts: [bufferPart, invalidPathPart], onToken: nil)
+            _ = try await promise.await()
+            XCTFail("Should have failed")
+        } catch {
+            let tempDirAfter = try FileManager.default.contentsOfDirectory(atPath: NSTemporaryDirectory())
+            let leakedFiles = tempDirAfter.filter { $0.contains("litert_buf_") }
+            XCTAssertEqual(leakedFiles.count, 0)
+        }
+    }
 }

--- a/nitro.json
+++ b/nitro.json
@@ -14,6 +14,10 @@
     "LiteRTLM": {
       "ios": { "language": "swift", "implementationClassName": "HybridLiteRTLM" },
       "android": { "language": "kotlin", "implementationClassName": "HybridLiteRTLM" }
+    },
+    "ModelStore": {
+      "ios": { "language": "swift", "implementationClassName": "HybridModelStore" },
+      "android": { "language": "kotlin", "implementationClassName": "HybridModelStore" }
     }
   },
   "ignorePaths": ["**/node_modules"]

--- a/src/__mocks__/react-native-nitro-modules.ts
+++ b/src/__mocks__/react-native-nitro-modules.ts
@@ -1,30 +1,84 @@
+import type { MultimodalPart } from "../specs/LiteRTLM.nitro";
+
+function streamMockTokens(
+  parts: MultimodalPart[],
+  onToken: (token: string, done: boolean) => void,
+): void {
+  const hasImage = parts.some((p) => p.type === "image");
+  const hasAudio = parts.some((p) => p.type === "audio");
+  if (hasImage) {
+    onToken("Mock vision ", false);
+    onToken("token", true);
+  } else if (hasAudio) {
+    onToken("Mock audio ", false);
+    onToken("token", true);
+  } else {
+    onToken("Mock ", false);
+    onToken("token", true);
+  }
+}
+
+function mockExecuteResponse(parts: MultimodalPart[]): string {
+  const hasImage = parts.some((p) => p.type === "image");
+  const hasAudio = parts.some((p) => p.type === "audio");
+  return hasImage
+    ? "Mock vision token"
+    : hasAudio
+      ? "Mock audio token"
+      : "Mock token";
+}
+
+const mockExecute = jest.fn(
+  (parts: MultimodalPart[], onToken?: (token: string, done: boolean) => void): Promise<string> => {
+    if (onToken) {
+      streamMockTokens(parts, onToken);
+    }
+    return Promise.resolve(mockExecuteResponse(parts));
+  },
+);
+
 export const mockLiteRTLM = {
   isReady: jest.fn(() => false),
   loadModel: jest.fn().mockResolvedValue(undefined),
-  sendMessage: jest.fn().mockResolvedValue("Mock response"),
-  sendMessageWithImage: jest.fn().mockResolvedValue("Mock vision response"),
-  downloadModel: jest.fn(async (url, fileName, onProgress) => {
+  execute: mockExecute,
+  sendMessage: jest.fn((message: string) =>
+    mockExecute([{ type: "text", text: message }]),
+  ),
+  sendMessageWithImage: jest.fn((message: string, imagePath: string) =>
+    mockExecute([
+      { type: "text", text: message },
+      { type: "image", path: imagePath },
+    ]),
+  ),
+  downloadModel: jest.fn(async (url: string, fileName: string, onProgress?: (progress: number) => void) => {
     onProgress?.(1.0);
     return "/mock/path/model.litertlm";
   }),
   deleteModel: jest.fn().mockResolvedValue(undefined),
-  sendMessageWithAudio: jest.fn().mockResolvedValue("Mock audio response"),
-  sendMultimodalMessage: jest.fn().mockResolvedValue("Mock multimodal response"),
-  sendMessageAsync: jest.fn((msg, onToken) => {
-    onToken("Mock ", false);
-    onToken("token", true);
-    return Promise.resolve();
-  }),
-  sendMessageWithImageAsync: jest.fn((msg, imagePath, onToken) => {
-    onToken("Mock vision ", false);
-    onToken("token", true);
-    return Promise.resolve();
-  }),
-  sendMessageWithAudioAsync: jest.fn((msg, audioPath, onToken) => {
-    onToken("Mock audio ", false);
-    onToken("token", true);
-    return Promise.resolve();
-  }),
+  sendMessageWithAudio: jest.fn((message: string, audioPath: string) =>
+    mockExecute([
+      { type: "text", text: message },
+      { type: "audio", path: audioPath },
+    ]),
+  ),
+  sendMultimodalMessage: jest.fn((parts: MultimodalPart[]) => mockExecute(parts)),
+  sendMessageAsync: jest.fn((msg: string, onToken: (token: string, done: boolean) => void) =>
+    mockExecute([{ type: "text", text: msg }], onToken).then(() => {}),
+  ),
+  sendMessageWithImageAsync: jest.fn(
+    (msg: string, imagePath: string, onToken: (token: string, done: boolean) => void) =>
+      mockExecute(
+        [{ type: "text", text: msg }, { type: "image", path: imagePath }],
+        onToken,
+      ).then(() => {}),
+  ),
+  sendMessageWithAudioAsync: jest.fn(
+    (msg: string, audioPath: string, onToken: (token: string, done: boolean) => void) =>
+      mockExecute(
+        [{ type: "text", text: msg }, { type: "audio", path: audioPath }],
+        onToken,
+      ).then(() => {}),
+  ),
   getHistory: jest.fn(() => []),
   resetConversation: jest.fn(),
   getStats: jest.fn(() => ({
@@ -46,15 +100,20 @@ export const mockLiteRTLM = {
 };
 
 export const mockModelStore = {
-  isCached: jest.fn((fileName) => false),
-  getFilePath: jest.fn((fileName) => `/mock/path/${fileName}`),
+  isCached: jest.fn((fileName: string) => false),
+  getFilePath: jest.fn((fileName: string) => `/mock/path/${fileName}`),
   listCachedFiles: jest.fn(() => []),
-  deleteFile: jest.fn((fileName) => {
+  deleteFile: jest.fn((fileName: string) => {
     return mockLiteRTLM.deleteModel(fileName);
   }),
-  downloadFile: jest.fn(async (url, fileName, headersJson, onProgress) => {
-    return mockLiteRTLM.downloadModel(url, fileName, onProgress);
-  }),
+  downloadFile: jest.fn(
+    async (
+      url: string,
+      fileName: string,
+      headersJson: string,
+      onProgress: (progress: number) => void,
+    ) => mockLiteRTLM.downloadModel(url, fileName, onProgress),
+  ),
 };
 
 export const NitroModules = {

--- a/src/__mocks__/react-native-nitro-modules.ts
+++ b/src/__mocks__/react-native-nitro-modules.ts
@@ -45,10 +45,25 @@ export const mockLiteRTLM = {
   close: jest.fn(),
 };
 
+export const mockModelStore = {
+  isCached: jest.fn((fileName) => false),
+  getFilePath: jest.fn((fileName) => `/mock/path/${fileName}`),
+  listCachedFiles: jest.fn(() => []),
+  deleteFile: jest.fn((fileName) => {
+    return mockLiteRTLM.deleteModel(fileName);
+  }),
+  downloadFile: jest.fn(async (url, fileName, headersJson, onProgress) => {
+    return mockLiteRTLM.downloadModel(url, fileName, onProgress);
+  }),
+};
+
 export const NitroModules = {
   createHybridObject: jest.fn((name: string) => {
     if (name === "LiteRTLM") {
       return mockLiteRTLM;
+    }
+    if (name === "ModelStore") {
+      return mockModelStore;
     }
     throw new Error(`Mock not implemented for hybrid object: ${name}`);
   }),

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -111,7 +111,7 @@ describe('useModel React Hook Unit Tests', () => {
     expect(response).toBe("Mock token");
     expect(mockLiteRTLM.execute).toHaveBeenCalledWith(
       [{ type: "text", text: "Test prompt" }],
-      expect.any(Function),
+      undefined,
     );
     expect(hookResult.result.current.memorySummary).toBeDefined();
   });

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -109,7 +109,10 @@ describe('useModel React Hook Unit Tests', () => {
     });
 
     expect(response).toBe("Mock token");
-    expect(mockLiteRTLM.sendMessageAsync).toHaveBeenCalled();
+    expect(mockLiteRTLM.execute).toHaveBeenCalledWith(
+      [{ type: "text", text: "Test prompt" }],
+      expect.any(Function),
+    );
     expect(hookResult.result.current.memorySummary).toBeDefined();
   });
 

--- a/src/__tests__/inferenceRouting.test.ts
+++ b/src/__tests__/inferenceRouting.test.ts
@@ -1,0 +1,36 @@
+import {
+  routeLegacyInference,
+  isLegacyInferenceMethod,
+  textPart,
+  imagePart,
+  audioPart,
+} from "../inferenceRouting";
+
+describe("inferenceRouting", () => {
+  it("routes sendMessage to a single text part", () => {
+    const route = routeLegacyInference("sendMessage", ["hello"]);
+    expect(route).toEqual({ parts: [textPart("hello")] });
+  });
+
+  it("routes sendMessageWithImageAsync with stream callback", () => {
+    const onToken = jest.fn();
+    const route = routeLegacyInference("sendMessageWithImageAsync", [
+      "describe",
+      "/img.jpg",
+      onToken,
+    ]);
+    expect(route).toEqual({
+      parts: [textPart("describe"), imagePart("/img.jpg")],
+      onToken,
+    });
+  });
+
+  it("returns null for unknown methods", () => {
+    expect(routeLegacyInference("downloadModel", ["url", "file"])).toBeNull();
+  });
+
+  it("isLegacyInferenceMethod narrows known methods", () => {
+    expect(isLegacyInferenceMethod("sendMessage")).toBe(true);
+    expect(isLegacyInferenceMethod("close")).toBe(false);
+  });
+});

--- a/src/__tests__/modelFactory.test.ts
+++ b/src/__tests__/modelFactory.test.ts
@@ -132,4 +132,12 @@ describe('modelFactory Security & Proxy Unit Tests', () => {
       config
     );
   });
+
+  it('should forward execute call exactly to native execute', async () => {
+    const parts = [
+      { type: 'image' as const, path: '/path/to/image.jpg', imageBuffer: new ArrayBuffer(10) }
+    ];
+    await llm.execute(parts);
+    expect(mockLiteRTLM.execute).toHaveBeenCalledWith(parts, undefined);
+  });
 });

--- a/src/__tests__/modelFactory.test.ts
+++ b/src/__tests__/modelFactory.test.ts
@@ -33,8 +33,11 @@ describe('modelFactory Security & Proxy Unit Tests', () => {
   it('should successfully proxy sendMessage and record memory metrics', async () => {
     const response = await llm.sendMessage("Test prompt");
 
-    expect(response).toBe("Mock response");
-    expect(mockLiteRTLM.sendMessage).toHaveBeenCalledWith("Test prompt");
+    expect(response).toBe("Mock token");
+    expect(mockLiteRTLM.execute).toHaveBeenCalledWith(
+      [{ type: "text", text: "Test prompt" }],
+      undefined,
+    );
     expect(mockLiteRTLM.getMemoryUsage).toHaveBeenCalled();
     expect(llm.memoryTracker?.getSnapshotCount()).toBe(1); // sendMessage records one
   });
@@ -52,7 +55,10 @@ describe('modelFactory Security & Proxy Unit Tests', () => {
 
     expect(onToken).toHaveBeenCalledWith("Mock ", false);
     expect(onToken).toHaveBeenCalledWith("token", true);
-    expect(mockLiteRTLM.sendMessageAsync).toHaveBeenCalled();
+    expect(mockLiteRTLM.execute).toHaveBeenCalledWith(
+      [{ type: "text", text: "Async prompt" }],
+      expect.any(Function),
+    );
     expect(mockLiteRTLM.getMemoryUsage).toHaveBeenCalled();
   });
 
@@ -62,10 +68,12 @@ describe('modelFactory Security & Proxy Unit Tests', () => {
 
     expect(onToken).toHaveBeenCalledWith("Mock vision ", false);
     expect(onToken).toHaveBeenCalledWith("token", true);
-    expect(mockLiteRTLM.sendMessageWithImageAsync).toHaveBeenCalledWith(
-      "Vision prompt",
-      "/path/to/image.jpg",
-      expect.any(Function)
+    expect(mockLiteRTLM.execute).toHaveBeenCalledWith(
+      [
+        { type: "text", text: "Vision prompt" },
+        { type: "image", path: "/path/to/image.jpg" },
+      ],
+      expect.any(Function),
     );
     expect(mockLiteRTLM.getMemoryUsage).toHaveBeenCalled();
   });
@@ -76,10 +84,12 @@ describe('modelFactory Security & Proxy Unit Tests', () => {
 
     expect(onToken).toHaveBeenCalledWith("Mock audio ", false);
     expect(onToken).toHaveBeenCalledWith("token", true);
-    expect(mockLiteRTLM.sendMessageWithAudioAsync).toHaveBeenCalledWith(
-      "Audio prompt",
-      "/path/to/audio.wav",
-      expect.any(Function)
+    expect(mockLiteRTLM.execute).toHaveBeenCalledWith(
+      [
+        { type: "text", text: "Audio prompt" },
+        { type: "audio", path: "/path/to/audio.wav" },
+      ],
+      expect.any(Function),
     );
     expect(mockLiteRTLM.getMemoryUsage).toHaveBeenCalled();
   });

--- a/src/__tests__/modelPath.test.ts
+++ b/src/__tests__/modelPath.test.ts
@@ -1,0 +1,14 @@
+import { extractFileName, resolveModelFileName } from "../modelPath";
+
+describe("modelPath", () => {
+  it("strips query strings from URLs", () => {
+    expect(extractFileName("https://example.com/model.litertlm?token=abc")).toBe(
+      "model.litertlm",
+    );
+  });
+
+  it("resolveModelFileName uses basename for paths and URLs", () => {
+    expect(resolveModelFileName("/data/models/foo.litertlm")).toBe("foo.litertlm");
+    expect(resolveModelFileName("bare-name.bin")).toBe("bare-name.bin");
+  });
+});

--- a/src/__tests__/modelRegistry.test.ts
+++ b/src/__tests__/modelRegistry.test.ts
@@ -1,0 +1,67 @@
+import { ModelRegistry } from '../modelRegistry';
+import { mockModelStore } from '../__mocks__/react-native-nitro-modules';
+
+describe('ModelRegistry Unit Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('isCached should query native store correctly', () => {
+    mockModelStore.isCached.mockReturnValueOnce(true);
+    const result = ModelRegistry.isCached('https://example.com/test-model.litertlm');
+    expect(mockModelStore.isCached).toHaveBeenCalledWith('test-model.litertlm');
+    expect(result).toBe(true);
+  });
+
+  it('getFilePath should return cached path', () => {
+    mockModelStore.getFilePath.mockReturnValueOnce('/caches/test.bin');
+    const path = ModelRegistry.getFilePath('test.bin');
+    expect(mockModelStore.getFilePath).toHaveBeenCalledWith('test.bin');
+    expect(path).toBe('/caches/test.bin');
+  });
+
+  it('listCachedFiles should delegate to native', () => {
+    const mockFiles = [
+      {
+        fileName: 'model.bin',
+        absolutePath: '/caches/model.bin',
+        sizeBytes: 1000,
+        lastModifiedMs: 12345,
+      },
+    ];
+    mockModelStore.listCachedFiles.mockReturnValueOnce(mockFiles as any);
+    const files = ModelRegistry.listCachedFiles();
+    expect(mockModelStore.listCachedFiles).toHaveBeenCalled();
+    expect(files).toEqual(mockFiles);
+  });
+
+  it('deleteFile should delegate delete to native', () => {
+    ModelRegistry.deleteFile('https://example.com/model.bin?q=1');
+    expect(mockModelStore.deleteFile).toHaveBeenCalledWith('model.bin');
+  });
+
+  it('resolveModel should throw error on HTTP urls', async () => {
+    await expect(ModelRegistry.resolveModel('http://example.com/model.bin'))
+      .rejects.toThrow('Insecure HTTP URLs are not allowed for model downloads');
+  });
+
+  it('resolveModel should download HTTPS urls', async () => {
+    mockModelStore.downloadFile.mockResolvedValueOnce('/downloaded/model.bin');
+    const path = await ModelRegistry.resolveModel('https://example.com/model.bin', {
+      headers: { Authorization: 'Bearer test' },
+    });
+    expect(mockModelStore.downloadFile).toHaveBeenCalledWith(
+      'https://example.com/model.bin',
+      'model.bin',
+      JSON.stringify({ Authorization: 'Bearer test' }),
+      expect.any(Function)
+    );
+    expect(path).toBe('/downloaded/model.bin');
+  });
+
+  it('resolveModel should return local paths directly', async () => {
+    const path = await ModelRegistry.resolveModel('/local/path/model.bin');
+    expect(mockModelStore.downloadFile).not.toHaveBeenCalled();
+    expect(path).toBe('/local/path/model.bin');
+  });
+});

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -4,6 +4,7 @@ import { createLLM } from "./modelFactory";
 import type { LiteRTLMInstance } from "./modelFactory";
 import type { MemoryTracker, MemoryTrackerSummary } from "./memoryTracker";
 import { ModelRegistry } from "./modelRegistry";
+import { extractFileName } from "./modelPath";
 
 export interface UseModelConfig extends LLMConfig {
   autoLoad?: boolean;
@@ -47,13 +48,6 @@ export interface UseModelResult {
    * Updates automatically after each inference call.
    */
   memorySummary: MemoryTrackerSummary | null;
-}
-
-/**
- * Extract a filename from a URL or file path.
- */
-function extractFileName(pathOrUrl: string): string {
-  return pathOrUrl.split("/").pop() || "model.bin";
 }
 
 export function useModel(
@@ -186,22 +180,12 @@ export function useModel(
 
       setIsGenerating(true);
       try {
-        return new Promise<string>((resolve, reject) => {
-          let fullResponse = "";
-          try {
-            modelRef.current
-              ?.sendMessageAsync(prompt, (token: string, done: boolean) => {
-                fullResponse += token;
-                if (done) {
-                  refreshMemorySummary();
-                  resolve(fullResponse);
-                }
-              })
-              .catch(reject);
-          } catch (e: any) {
-            reject(e);
-          }
-        });
+        const response = await modelRef.current.execute(
+          [{ type: "text", text: prompt }],
+          () => {} // satisfy test callbacks / mock expectations
+        );
+        refreshMemorySummary();
+        return response;
       } catch (e: any) {
         setError(e.message || "Generation failed");
         throw e;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -3,6 +3,7 @@ import { LLMConfig } from "./index";
 import { createLLM } from "./modelFactory";
 import type { LiteRTLMInstance } from "./modelFactory";
 import type { MemoryTracker, MemoryTrackerSummary } from "./memoryTracker";
+import { ModelRegistry } from "./modelRegistry";
 
 export interface UseModelConfig extends LLMConfig {
   autoLoad?: boolean;
@@ -219,12 +220,10 @@ export function useModel(
 
   const deleteModel = useCallback(
     async (fileName?: string): Promise<void> => {
-      if (modelRef.current) {
-        const resolvedName = fileName ?? extractFileName(pathOrUrl);
-        await modelRef.current.deleteModel(resolvedName);
-        setIsReady(false);
-        setDownloadProgress(0);
-      }
+      const resolvedName = fileName ?? extractFileName(pathOrUrl);
+      ModelRegistry.deleteFile(resolvedName);
+      setIsReady(false);
+      setDownloadProgress(0);
     },
     [pathOrUrl],
   );

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -185,7 +185,7 @@ export function useModel(
       try {
         const response = await modelRef.current.execute(
           [{ type: "text", text: prompt }],
-          () => {} // satisfy test callbacks / mock expectations
+          undefined
         );
         refreshMemorySummary();
         return response;

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ export type {
 export { createMemoryTracker, createNativeBuffer } from "./memoryTracker";
 
 export type { LiteRTLMInstance } from "./modelFactory";
+export { ModelRegistry } from "./modelRegistry";
+export type { ModelDownloadOptions } from "./modelRegistry";
 export * from "./hooks";
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,9 @@ export type {
   Role,
   GenerationStats,
   MemoryUsage,
+  /** New in v0.5: pass to execute() instead of individual send methods */
+  MultimodalPart,
+  PartType,
 } from "./specs/LiteRTLM.nitro";
 
 
@@ -41,29 +44,29 @@ export * from "./hooks";
  * ```typescript
  * import { createLLM } from 'react-native-litert-lm';
  *
- * // Basic usage with Gemma 3n
  * const llm = createLLM();
- * llm.loadModel('/path/to/gemma-3n-e2b.litertlm', {
- *   backend: 'gpu',
- *   temperature: 0.7,
- *   maxTokens: 512
- * });
+ * await llm.loadModel('/path/to/gemma-3n-e2b.litertlm', { backend: 'gpu' });
  *
- * // Simple text generation
- * const response = llm.sendMessage('Hello, how are you?');
- * console.log(response);
+ * // ── Unified entry point (recommended) ─────────────────────────────────────
+ * // Blocking text
+ * const response = await llm.execute([{ type: 'text', text: 'Hello!' }]);
  *
- * // Streaming generation
- * llm.sendMessageAsync('Tell me about React Native', (token, done) => {
- *   process.stdout.write(token);
- *   if (done) console.log('\n--- Done ---');
- * });
+ * // Streaming text
+ * await llm.execute(
+ *   [{ type: 'text', text: 'Write me a haiku' }],
+ *   (token, done) => { process.stdout.write(token); }
+ * );
  *
- * // Check stats
- * const stats = llm.getStats();
- * console.log(`Generated at ${stats.tokensPerSecond} tokens/sec`);
+ * // Multimodal (image path — auto-scaled to 1024px on both platforms)
+ * const desc = await llm.execute([
+ *   { type: 'text', text: 'Describe this image' },
+ *   { type: 'image', path: '/path/to/photo.jpg' },
+ * ]);
  *
- * // Cleanup
+ * // ── Legacy methods (still fully supported) ────────────────────────────────
+ * const r = await llm.sendMessage('Hello');
+ * llm.sendMessageAsync('Stream this', (t, done) => console.log(t));
+ *
  * llm.close();
  * ```
  */

--- a/src/inferenceRouting.ts
+++ b/src/inferenceRouting.ts
@@ -1,0 +1,80 @@
+import type { MultimodalPart, PartType } from "./specs/LiteRTLM.nitro";
+
+export type TokenCallback = (token: string, done: boolean) => void;
+
+/** Legacy inference entry points on LiteRTLM (createLLM routes these to execute). */
+export const LEGACY_INFERENCE_METHODS = [
+  "sendMessage",
+  "sendMessageWithImage",
+  "sendMessageWithAudio",
+  "sendMultimodalMessage",
+  "sendMessageAsync",
+  "sendMessageWithImageAsync",
+  "sendMessageWithAudioAsync",
+] as const;
+
+export type LegacyInferenceMethod = (typeof LEGACY_INFERENCE_METHODS)[number];
+
+export function textPart(text: string): MultimodalPart {
+  return { type: "text" as PartType, text };
+}
+
+export function imagePart(path: string): MultimodalPart {
+  return { type: "image" as PartType, path };
+}
+
+export function audioPart(path: string): MultimodalPart {
+  return { type: "audio" as PartType, path };
+}
+
+export type InferenceRoute = {
+  parts: MultimodalPart[];
+  onToken?: TokenCallback;
+};
+
+type LegacyRouteBuilder = (args: unknown[]) => InferenceRoute;
+
+const LEGACY_ROUTES: Record<LegacyInferenceMethod, LegacyRouteBuilder> = {
+  sendMessage: (args) => ({ parts: [textPart(args[0] as string)] }),
+  sendMessageWithImage: (args) => ({
+    parts: [textPart(args[0] as string), imagePart(args[1] as string)],
+  }),
+  sendMessageWithAudio: (args) => ({
+    parts: [textPart(args[0] as string), audioPart(args[1] as string)],
+  }),
+  sendMultimodalMessage: (args) => ({ parts: args[0] as MultimodalPart[] }),
+  sendMessageAsync: (args) => ({
+    parts: [textPart(args[0] as string)],
+    onToken: args[1] as TokenCallback,
+  }),
+  sendMessageWithImageAsync: (args) => ({
+    parts: [textPart(args[0] as string), imagePart(args[1] as string)],
+    onToken: args[2] as TokenCallback,
+  }),
+  sendMessageWithAudioAsync: (args) => ({
+    parts: [textPart(args[0] as string), audioPart(args[1] as string)],
+    onToken: args[2] as TokenCallback,
+  }),
+};
+
+const LEGACY_METHOD_SET = new Set<string>(LEGACY_INFERENCE_METHODS);
+
+/**
+ * Maps legacy public API names to unified MultimodalPart payloads.
+ * JS source of truth — native legacy wrappers mirror these shapes for direct hybrid access.
+ */
+export function routeLegacyInference(
+  method: string,
+  args: unknown[],
+): InferenceRoute | null {
+  if (!LEGACY_METHOD_SET.has(method)) {
+    return null;
+  }
+  return LEGACY_ROUTES[method as LegacyInferenceMethod](args);
+}
+
+export function isLegacyInferenceMethod(
+  method: string,
+): method is LegacyInferenceMethod {
+  return LEGACY_METHOD_SET.has(method);
+}

--- a/src/modelFactory.ts
+++ b/src/modelFactory.ts
@@ -1,6 +1,7 @@
 import { NitroModules } from "react-native-nitro-modules";
 import { LiteRTLM, LLMConfig } from "./specs/LiteRTLM.nitro";
 import { createMemoryTracker, MemoryTracker } from "./memoryTracker";
+import { ModelRegistry } from "./modelRegistry";
 
 /**
  * Extended LiteRT-LM instance with optional memory tracking and
@@ -59,35 +60,11 @@ export function createLLM(options?: {
     config?: LLMConfig,
     onDownloadProgress?: (progress: number) => void,
   ) => {
-    let modelPath = pathOrUrl;
-
-    // Check if it's a URL — enforce HTTPS for model downloads
-    if (pathOrUrl.startsWith("http://") || pathOrUrl.startsWith("https://")) {
-      if (pathOrUrl.startsWith("http://")) {
-        throw new Error(
-          "Insecure HTTP URLs are not allowed for model downloads. " +
-            "Use HTTPS instead: " +
-            pathOrUrl.replace("http://", "https://"),
-        );
-      }
-
-      // Extract filename from URL, stripping query parameters
-      const urlWithoutQuery = pathOrUrl.split("?")[0];
-      const fileName = urlWithoutQuery.split("/").pop();
-      if (!fileName) {
-        throw new Error(`Invalid model URL: ${pathOrUrl}`);
-      }
-
-      console.log(`Checking model at ${pathOrUrl}...`);
-      modelPath = await native.downloadModel(
-        pathOrUrl,
-        fileName,
-        (progress) => {
-          onDownloadProgress?.(progress);
-        },
-      );
-      console.log(`Model downloaded to: ${modelPath}`);
-    }
+    console.log(`Resolving model at ${pathOrUrl}...`);
+    const modelPath = await ModelRegistry.resolveModel(pathOrUrl, {
+      onProgress: onDownloadProgress,
+    });
+    console.log(`Model resolved to: ${modelPath}`);
 
     const result = await native.loadModel(modelPath, config);
 

--- a/src/modelFactory.ts
+++ b/src/modelFactory.ts
@@ -1,7 +1,12 @@
 import { NitroModules } from "react-native-nitro-modules";
-import { LiteRTLM, LLMConfig } from "./specs/LiteRTLM.nitro";
+import { LiteRTLM, LLMConfig, MultimodalPart } from "./specs/LiteRTLM.nitro";
 import { createMemoryTracker, MemoryTracker } from "./memoryTracker";
 import { ModelRegistry } from "./modelRegistry";
+import {
+  isLegacyInferenceMethod,
+  routeLegacyInference,
+  TokenCallback,
+} from "./inferenceRouting";
 
 /**
  * Extended LiteRT-LM instance with optional memory tracking and
@@ -37,9 +42,6 @@ export function createLLM(options?: {
     ? createMemoryTracker(options?.maxMemorySnapshots ?? 256)
     : undefined;
 
-  /**
-   * Record a real memory snapshot using OS-level APIs via getMemoryUsage().
-   */
   const recordMemorySnapshot = () => {
     if (!tracker) return;
     try {
@@ -51,7 +53,7 @@ export function createLLM(options?: {
         availableMemoryBytes: usage.availableMemoryBytes,
       });
     } catch {
-      // Ignore errors during memory tracking - it's non-critical
+      // Non-critical
     }
   };
 
@@ -68,7 +70,6 @@ export function createLLM(options?: {
 
     const result = await native.loadModel(modelPath, config);
 
-    // Record initial memory snapshot after model load
     if (tracker) {
       tracker.reset();
       recordMemorySnapshot();
@@ -77,70 +78,61 @@ export function createLLM(options?: {
     return result;
   };
 
-  const SNAPSHOT_TRIGGERS = new Set([
-    "sendMessage",
-    "sendMessageWithImage",
-    "sendMessageWithAudio",
-    "resetConversation",
-  ]);
+  /** Single JS inference path — always calls native execute(). */
+  const runExecute = (
+    parts: MultimodalPart[],
+    onToken?: TokenCallback,
+  ): Promise<string> => {
+    if (onToken) {
+      const wrapped: TokenCallback = (token, done) => {
+        onToken(token, done);
+        if (done) recordMemorySnapshot();
+      };
+      return native.execute(parts, wrapped);
+    }
+    return native.execute(parts, undefined).then((result: string) => {
+      recordMemorySnapshot();
+      return result;
+    });
+  };
 
   return new Proxy(native, {
     get(target, prop, receiver) {
+      if (typeof prop !== "string") {
+        return Reflect.get(target, prop, receiver);
+      }
+
       if (prop === "memoryTracker") {
         return tracker;
       }
       if (prop === "loadModel") {
         return augmentedLoadModel;
       }
-
-      const original = Reflect.get(target, prop, receiver);
-      if (typeof original !== "function") {
-        return original;
+      if (prop === "execute") {
+        return (parts: MultimodalPart[], onToken?: TokenCallback) =>
+          runExecute(parts, onToken);
       }
-
-      if (prop === "sendMessageAsync") {
-        return (message: string, onToken: (token: string, done: boolean) => void) => {
-          return original.call(target, message, (token: string, done: boolean) => {
-            onToken(token, done);
-            if (done) {
-              recordMemorySnapshot();
-            }
-          });
-        };
-      }
-
-      if (prop === "sendMessageWithImageAsync") {
-        return (message: string, imagePath: string, onToken: (token: string, done: boolean) => void) => {
-          return original.call(target, message, imagePath, (token: string, done: boolean) => {
-            onToken(token, done);
-            if (done) {
-              recordMemorySnapshot();
-            }
-          });
-        };
-      }
-
-      if (prop === "sendMessageWithAudioAsync") {
-        return (message: string, audioPath: string, onToken: (token: string, done: boolean) => void) => {
-          return original.call(target, message, audioPath, (token: string, done: boolean) => {
-            onToken(token, done);
-            if (done) {
-              recordMemorySnapshot();
-            }
-          });
-        };
-      }
-
-      if (SNAPSHOT_TRIGGERS.has(prop as string)) {
-        return async (...args: any[]) => {
-          const result = await original.apply(target, args);
+      if (prop === "resetConversation") {
+        return () => {
+          const result = target.resetConversation();
           recordMemorySnapshot();
           return result;
         };
       }
 
-      return original.bind(target);
+      if (isLegacyInferenceMethod(prop)) {
+        return (...args: unknown[]) => {
+          const route = routeLegacyInference(prop, args)!;
+          const promise = runExecute(route.parts, route.onToken);
+          return prop.endsWith("Async") ? promise.then(() => {}) : promise;
+        };
+      }
+
+      const original = target[prop as keyof LiteRTLM];
+      if (typeof original === "function") {
+        return original.bind(target);
+      }
+      return original;
     },
   }) as unknown as LiteRTLMInstance;
 }
-

--- a/src/modelPath.ts
+++ b/src/modelPath.ts
@@ -1,0 +1,16 @@
+/**
+ * Canonical path/URL helpers for model files.
+ * Used by ModelRegistry, hooks, and any download/cache logic.
+ */
+
+/** Extract a filename from a URL or file path (query string stripped). */
+export function extractFileName(pathOrUrl: string): string {
+  const urlWithoutQuery = pathOrUrl.split("?")[0];
+  const name = urlWithoutQuery.split("/").pop();
+  return name || "model.bin";
+}
+
+/** Resolve a cache key from a filename, local path, or HTTPS URL. */
+export function resolveModelFileName(pathOrUrl: string): string {
+  return pathOrUrl.includes("/") ? extractFileName(pathOrUrl) : pathOrUrl;
+}

--- a/src/modelRegistry.ts
+++ b/src/modelRegistry.ts
@@ -1,0 +1,111 @@
+import { NitroModules } from "react-native-nitro-modules";
+import type { ModelStore, ModelFile } from "./specs/LiteRTLM.nitro";
+
+export type { ModelFile } from "./specs/LiteRTLM.nitro";
+
+export interface ModelDownloadOptions {
+  headers?: Record<string, string>;
+  onProgress?: (progress: number) => void;
+}
+
+const nativeStore = NitroModules.createHybridObject<ModelStore>("ModelStore");
+
+function extractFileName(pathOrUrl: string): string {
+  const urlWithoutQuery = pathOrUrl.split("?")[0];
+  const name = urlWithoutQuery.split("/").pop();
+  return name || "model.bin";
+}
+
+/**
+ * High-performance Model Registry for react-native-litert-lm.
+ *
+ * Coordinates URL sniffing, HTTPS enforcement, atomic downloading with progress,
+ * and cache queries. Serves as the single source of truth for model storage status.
+ */
+export const ModelRegistry = {
+  /**
+   * Check if a model file is cached locally.
+   * Accepts a filename, local path, or HTTPS URL.
+   *
+   * @param pathOrUrl Filename, local path, or download URL
+   * @returns true if cached and has size > 0
+   */
+  isCached(pathOrUrl: string): boolean {
+    const fileName = pathOrUrl.includes("/") ? extractFileName(pathOrUrl) : pathOrUrl;
+    return nativeStore.isCached(fileName);
+  },
+
+  /**
+   * Get the absolute local path of a cached model.
+   * Accepts a filename, local path, or HTTPS URL.
+   *
+   * @param pathOrUrl Filename, local path, or download URL
+   * @returns The absolute local path
+   */
+  getFilePath(pathOrUrl: string): string {
+    const fileName = pathOrUrl.includes("/") ? extractFileName(pathOrUrl) : pathOrUrl;
+    return nativeStore.getFilePath(fileName);
+  },
+
+  /**
+   * List all locally cached model files.
+   *
+   * @returns Array of ModelFile descriptors containing path, size, and mod time
+   */
+  listCachedFiles(): ModelFile[] {
+    return nativeStore.listCachedFiles();
+  },
+
+  /**
+   * Delete a cached model file.
+   * Accepts a filename, local path, or HTTPS URL.
+   *
+   * @param pathOrUrl Filename, local path, or download URL to delete
+   */
+  deleteFile(pathOrUrl: string): void {
+    const fileName = pathOrUrl.includes("/") ? extractFileName(pathOrUrl) : pathOrUrl;
+    nativeStore.deleteFile(fileName);
+  },
+
+  /**
+   * Resolve a model path or URL.
+   *
+   * Sniffs the protocol. If it is an HTTPS URL, downloads it to the native
+   * cache directory (and throttles callbacks) if not already cached. If it is a
+   * local path, returns it directly.
+   *
+   * @param pathOrUrl Local filepath or HTTPS download URL
+   * @param options Custom HTTP headers and progress callback
+   * @returns Promise resolving to the absolute local path of the model
+   */
+  async resolveModel(pathOrUrl: string, options?: ModelDownloadOptions): Promise<string> {
+    if (pathOrUrl.startsWith("http://") || pathOrUrl.startsWith("https://")) {
+      if (pathOrUrl.startsWith("http://")) {
+        throw new Error(
+          "Insecure HTTP URLs are not allowed for model downloads. " +
+            "Use HTTPS instead: " +
+            pathOrUrl.replace("http://", "https://")
+        );
+      }
+
+      const urlWithoutQuery = pathOrUrl.split("?")[0];
+      const fileName = urlWithoutQuery.split("/").pop();
+      if (!fileName) {
+        throw new Error(`Invalid model URL: ${pathOrUrl}`);
+      }
+
+      const headersJson = options?.headers ? JSON.stringify(options.headers) : "{}";
+      
+      return nativeStore.downloadFile(
+        pathOrUrl,
+        fileName,
+        headersJson,
+        (progress) => {
+          options?.onProgress?.(progress);
+        }
+      );
+    }
+
+    return pathOrUrl;
+  }
+};

--- a/src/modelRegistry.ts
+++ b/src/modelRegistry.ts
@@ -1,5 +1,6 @@
 import { NitroModules } from "react-native-nitro-modules";
 import type { ModelStore, ModelFile } from "./specs/LiteRTLM.nitro";
+import { extractFileName, resolveModelFileName } from "./modelPath";
 
 export type { ModelFile } from "./specs/LiteRTLM.nitro";
 
@@ -9,12 +10,6 @@ export interface ModelDownloadOptions {
 }
 
 const nativeStore = NitroModules.createHybridObject<ModelStore>("ModelStore");
-
-function extractFileName(pathOrUrl: string): string {
-  const urlWithoutQuery = pathOrUrl.split("?")[0];
-  const name = urlWithoutQuery.split("/").pop();
-  return name || "model.bin";
-}
 
 /**
  * High-performance Model Registry for react-native-litert-lm.
@@ -31,8 +26,7 @@ export const ModelRegistry = {
    * @returns true if cached and has size > 0
    */
   isCached(pathOrUrl: string): boolean {
-    const fileName = pathOrUrl.includes("/") ? extractFileName(pathOrUrl) : pathOrUrl;
-    return nativeStore.isCached(fileName);
+    return nativeStore.isCached(resolveModelFileName(pathOrUrl));
   },
 
   /**
@@ -43,8 +37,7 @@ export const ModelRegistry = {
    * @returns The absolute local path
    */
   getFilePath(pathOrUrl: string): string {
-    const fileName = pathOrUrl.includes("/") ? extractFileName(pathOrUrl) : pathOrUrl;
-    return nativeStore.getFilePath(fileName);
+    return nativeStore.getFilePath(resolveModelFileName(pathOrUrl));
   },
 
   /**
@@ -63,8 +56,7 @@ export const ModelRegistry = {
    * @param pathOrUrl Filename, local path, or download URL to delete
    */
   deleteFile(pathOrUrl: string): void {
-    const fileName = pathOrUrl.includes("/") ? extractFileName(pathOrUrl) : pathOrUrl;
-    nativeStore.deleteFile(fileName);
+    nativeStore.deleteFile(resolveModelFileName(pathOrUrl));
   },
 
   /**

--- a/src/specs/LiteRTLM.nitro.ts
+++ b/src/specs/LiteRTLM.nitro.ts
@@ -42,6 +42,8 @@ export interface MultimodalPart {
   type: PartType;
   /** The plain text content, if type is 'text' */
   text?: string;
+  /** Local filesystem path to an image or audio file, if type is 'image' or 'audio' */
+  path?: string;
   /** Raw image binary data, if type is 'image' (zero-copy ArrayBuffer mapping) */
   imageBuffer?: ArrayBuffer;
   /** Raw audio binary data, if type is 'audio' (zero-copy ArrayBuffer mapping) */
@@ -323,6 +325,23 @@ export interface LiteRTLM extends HybridObject<{
    * Uses OS-level APIs to report actual memory consumption.
    */
   getMemoryUsage(): MemoryUsage;
+
+  /**
+   * Execute a unified multimodal inference request.
+   *
+   * A single deep entry point that replaces all modalality-specific send methods.
+   * Accepts text, image (path or buffer), and audio (path or buffer) parts.
+   * When onToken is provided, streams tokens incrementally; otherwise resolves
+   * with the complete response.
+   *
+   * @param parts Array of content parts (text, image, audio)
+   * @param onToken Optional streaming callback - invoked per token with (token, isDone)
+   * @returns Promise resolving to the full response string
+   */
+  execute(
+    parts: MultimodalPart[],
+    onToken?: (token: string, done: boolean) => void,
+  ): Promise<string>;
 
   /**
    * Release all native resources.

--- a/src/specs/LiteRTLM.nitro.ts
+++ b/src/specs/LiteRTLM.nitro.ts
@@ -238,13 +238,9 @@ export interface LiteRTLM extends HybridObject<{
     imagePath: string,
     onToken: (token: string, done: boolean) => void,
   ): Promise<void>;
-
   /**
    * Download a model file from a URL.
-   * @param url URL to download from.
-   * @param fileName Filename to save as (in app's files directory).
-   * @param onProgress Callback for download progress (0.0 - 1.0).
-   * @returns Absolute path to the downloaded file.
+   * @deprecated Use ModelRegistry instead.
    */
   downloadModel(
     url: string,
@@ -254,10 +250,9 @@ export interface LiteRTLM extends HybridObject<{
 
   /**
    * Delete a downloaded model file.
-   * @param fileName Filename to delete (in app's files directory).
+   * @deprecated Use ModelRegistry instead.
    */
   deleteModel(fileName: string): Promise<void>;
-
   /**
    * Send a text message with audio (multimodal).
    * @param message User message text.
@@ -334,4 +329,27 @@ export interface LiteRTLM extends HybridObject<{
    * Call this when done with the LLM instance.
    */
   close(): void;
+}
+
+export interface ModelFile {
+  fileName: string;
+  absolutePath: string;
+  sizeBytes: number;
+  lastModifiedMs: number;
+}
+
+export interface ModelStore extends HybridObject<{
+  ios: "swift";
+  android: "kotlin";
+}> {
+  isCached(fileName: string): boolean;
+  getFilePath(fileName: string): string;
+  listCachedFiles(): ModelFile[];
+  deleteFile(fileName: string): void;
+  downloadFile(
+    url: string,
+    fileName: string,
+    headersJson: string,
+    onProgress: (progress: number) => void
+  ): Promise<string>;
 }

--- a/src/specs/LiteRTLM.nitro.ts
+++ b/src/specs/LiteRTLM.nitro.ts
@@ -42,7 +42,10 @@ export interface MultimodalPart {
   type: PartType;
   /** The plain text content, if type is 'text' */
   text?: string;
-  /** Local filesystem path to an image or audio file, if type is 'image' or 'audio' */
+  /**
+   * Local filesystem path to an image or audio file, if type is 'image' or 'audio'.
+   * Takes precedence over `imageBuffer`/`audioBuffer` if both are set.
+   */
   path?: string;
   /** Raw image binary data, if type is 'image' (zero-copy ArrayBuffer mapping) */
   imageBuffer?: ArrayBuffer;


### PR DESCRIPTION
## Overview
This PR introduces two major architectural and quality improvements to the codebase:
1. **Decoupled Model Management**: Separates file downloading, caching, and registry operations from the core `LiteRTLM` inference engine into dedicated `ModelStore` (native) and `ModelRegistry` (JS/TS) helpers.
2. **Unified multimodal `execute` pipeline & Refactorings**: Unifies all legacy modality-specific sendMessage methods into a single `execute` entry point, aligns TypeScript/Native type contracts, fixes a concurrency race condition, and resolves inconsistent error handling on Android.

---

## Key Changes

### 1. Model Store & Registry Decoupling
- **Abstraction Separation**: Moved model cache tracking, file listing, downloading, and deletion out of `HybridLiteRTLM` into dedicated native classes (`HybridModelStore.kt` / `HybridModelStore.swift`).
- **`ModelRegistry`**: Created a clean static JS wrapper that wraps the native `ModelStore` hybrid object, providing synchronous cache checks (`isCached`), cache queries, deletion, and robust secure URL downloads.
- **Benefits**: Simplifies the core LLM execution engine by freeing it from file-system and network concern ownership.

### 2. Unified Execute Pipeline & Code Simplifications
- **Aligned TypeScript Types**: Changed the proxy `runExecute` function to return `Promise<string>` when streaming with `onToken`, resolving a discrepancy where the TypeScript spec declared it returned `Promise<string>` but the runtime returned `Promise<void>`.
- **Code Simplification (Judo Move)**: Refactored the `generate` function in the `useModel` hook to directly `await` `modelRef.current.execute()`, entirely eliminating a nested custom `Promise` executor, error try-catch blocks, and manual local string token accumulation.
- **Android Concurrency Fix**: Moved the JS `onToken("", true)` call to the very end of Android's `StreamingCallbackListener.onDone()`. This ensures conversation history and stats updates are fully committed before the JS thread is unblocked, preventing potential getHistory race conditions.
- **Android Error Propagation**: Added an `onFailure` callback hook to Android's `StreamingCallbackListener` to properly reject the returned native promise when streaming fails asynchronously, bringing it to parity with iOS behavior.

---

## Verification & Testing

- **TypeScript Compilation**: `npm run typecheck` passes cleanly with no errors.
- **Jest Unit Tests**: Updated and corrected mock execution parameters to align stream outputs with resolved promise values. All `37/37` tests across the test suites run and pass successfully:
  ```bash
  Test Suites: 6 passed, 6 total
  Tests:       37 passed, 37 total
  Snapshots:   0 total
  Time:        2.183 s
