### PR TITLE
feat: upgrade LiteRT-LM engine to 0.15.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,8 +71,13 @@ jobs:
       - name: Compile Swift
         run: |
           WORKSPACE=$(find example/ios -name "*.xcworkspace" -maxdepth 1 | head -1)
+          # CLiteRTLM.xcframework ships an arm64-only simulator slice; a generic
+          # simulator build (arm64 + x86_64) finds no matching slice and the
+          # CLiteRTLM module resolves for neither arch. Same flags as codeql.yml.
           xcodebuild -workspace "$WORKSPACE" \
             -scheme react-native-litert-lm \
             -sdk iphonesimulator \
             -configuration Debug \
+            ARCHS=arm64 \
+            EXCLUDED_ARCHS=x86_64 \
             build

--- a/.github/workflows/litert-release-watch.yml
+++ b/.github/workflows/litert-release-watch.yml
@@ -63,7 +63,7 @@ jobs:
           {
             echo "Upstream released **${{ steps.compare.outputs.latest_tag }}**; this package pins **v${{ steps.compare.outputs.pinned }}**."
             echo
-            echo "Checklist (see docs/LiteRT-LM v0.14.0 Upgrade.md for the pattern):"
+            echo "Checklist (see docs/LiteRT-LM v0.15.0 Upgrade.md for the pattern):"
             echo "- [ ] Bump \`litertLm\` versions in package.json"
             echo "- [ ] Re-vendor \`cpp/include\` headers"
             echo "- [ ] Refresh \`ios/Frameworks\` via scripts/download-ios-frameworks.sh"

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Other `.litertlm` models (Gemma 3 1B, Phi-4 Mini, Qwen 2.5 1.5B) download manual
 | --- | --- |
 | React Native | 0.76+ |
 | react-native-nitro-modules | 0.36.0+ |
-| LiteRT-LM engine | 0.14.0 |
+| LiteRT-LM engine | 0.15.0 |
 | Android | API 26+, arm64-v8a — CPU (all), GPU (OpenCL/Pixel only), NPU |
 | iOS | 15.1+, arm64 — CPU, GPU (Metal; auto-fallback to CPU) |
 

--- a/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
+++ b/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
@@ -647,18 +647,9 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
             } else {
                 null
             },
+            // Available since LiteRT-LM 0.15.0 (previously iOS-only)
+            maxOutputToken = maxOutputTokens,
         )
-        // TODO: maxOutputTokens is not configurable on Android — the Kotlin SDK's
-        // ConversationConfig does not expose this parameter. Only EngineConfig.maxNumTokens
-        // (context budget) is supported. maxOutputTokens is effective on iOS only.
-        //
-        // Upstream is actively adding max_output_tokens across API surfaces:
-        //   - C API:    PR #2470 (merged 2026-06-04)
-        //   - Python:   PR #2476 (merged 2026-06-04)
-        //   - OpenAI:   PR #2433 (in progress)
-        //   - Kotlin:   Not yet available — track at https://github.com/google-ai-edge/LiteRT-LM
-        //
-        // Once the Kotlin SDK exposes this, wire it via ConversationConfig here.
         conversation = engine!!.createConversation(convConfig)
     }
 
@@ -696,10 +687,12 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
         onToken: ((token: String, done: Boolean) -> Unit)?,
         options: ExecuteOptions?,
     ): Promise<String> {
-        // Per-message options (maxOutputTokens, visualTokenBudget) are iOS-only:
-        // the Kotlin SDK's sendMessage does not accept per-message args.
+        // Per-message overrides (maxOutputTokens, visualTokenBudget) are not wired
+        // on Android yet — the session-level maxOutputTokens from LLMConfig applies.
+        // The Kotlin SDK supports per-call maxOutputToken since 0.15.0; wiring it
+        // here is tracked as a follow-up.
         if (options?.maxOutputTokens != null || options?.visualTokenBudget != null) {
-            Log.w(TAG, "execute options (maxOutputTokens/visualTokenBudget) are not supported on Android — session defaults apply")
+            Log.w(TAG, "per-message execute options (maxOutputTokens/visualTokenBudget) are not supported on Android — session config applies")
         }
         // Preprocess synchronously on the JS/JSI thread to safely extract JS buffer bytes
         val preprocessed = parts.map { part ->

--- a/cpp/include/README.md
+++ b/cpp/include/README.md
@@ -6,11 +6,11 @@ copies pinned to the LiteRT-LM version in `package.json` (`litertLm.version`).
 
 ## If Headers Are Missing
 
-If you get compilation errors like `litert_lm_engine.h: No such file or directory`, re-download the headers (replace `v0.14.0` with the pinned version):
+If you get compilation errors like `litert_lm_engine.h: No such file or directory`, re-download the headers (replace `v0.15.0` with the pinned version):
 
 ```bash
-curl -sL "https://raw.githubusercontent.com/google-ai-edge/LiteRT-LM/v0.14.0/c/engine.h" -o litert_lm_engine.h
-curl -sL "https://raw.githubusercontent.com/google-ai-edge/LiteRT-LM/v0.14.0/schema/capabilities/capabilities_c.h" -o capabilities_c.h
+curl -sL "https://raw.githubusercontent.com/google-ai-edge/LiteRT-LM/v0.15.0/c/engine.h" -o litert_lm_engine.h
+curl -sL "https://raw.githubusercontent.com/google-ai-edge/LiteRT-LM/v0.15.0/schema/capabilities/capabilities_c.h" -o capabilities_c.h
 ```
 
 The expected directory structure:

--- a/cpp/include/litert_lm_engine.h
+++ b/cpp/include/litert_lm_engine.h
@@ -38,39 +38,81 @@ extern "C" {
 #endif
 
 // Opaque pointer for the LiteRT LM Engine.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmEngine LiteRtLmEngine;
 
 // Opaque pointer for the LiteRT LM Session.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmSession LiteRtLmSession;
 
 // Opaque pointer for the LiteRT LM Responses.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmResponses LiteRtLmResponses;
 
 // Opaque pointer for the LiteRT LM Engine Settings.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmEngineSettings LiteRtLmEngineSettings;
 
 // Opaque pointer for the LiteRT LM Benchmark Info.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmBenchmarkInfo LiteRtLmBenchmarkInfo;
 
 // Opaque pointer for the LiteRT LM Conversation.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmConversation LiteRtLmConversation;
 
 // Opaque pointer for the LiteRT LM Conversation Optional Args.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmConversationOptionalArgs
     LiteRtLmConversationOptionalArgs;
 
+// Opaque pointer for the LiteRT LM Repetition Penalty Config.
+//
+// Added in version 0.1.0.
+typedef struct LiteRtLmRepetitionPenaltyConfig LiteRtLmRepetitionPenaltyConfig;
+
+// Opaque pointer for the LiteRT LM No Repeat Ngram Config.
+//
+// Added in version 0.1.0.
+typedef struct LiteRtLmNoRepeatNgramConfig LiteRtLmNoRepeatNgramConfig;
+
+// Opaque pointer for the LiteRT LM Suppress Tokens Config.
+//
+// Added in version 0.1.0.
+typedef struct LiteRtLmSuppressTokensConfig LiteRtLmSuppressTokensConfig;
+
+// Opaque pointer for the LiteRT LM Thinking Config.
+//
+// Added in version 0.1.0.
+typedef struct LiteRtLmThinkingConfig LiteRtLmThinkingConfig;
+
 // Opaque pointer for a JSON response.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmJsonResponse LiteRtLmJsonResponse;
 
 // Opaque pointer for a detokenize result.
 // Use `litert_lm_detokenize_result_delete` to free memory.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmDetokenizeResult LiteRtLmDetokenizeResult;
 
 // Opaque pointer for a tokenize result.
 // Use `litert_lm_tokenize_result_delete` to free memory.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmTokenizeResult LiteRtLmTokenizeResult;
 
 // Represents the type of a TokenUnion.
+//
+// Added in version 0.1.0.
 typedef enum {
   kLiteRtLmTokenUnionTypeString = 0,
   kLiteRtLmTokenUnionTypeIds = 1,
@@ -80,25 +122,37 @@ typedef enum {
 // Represents a single start or stop token, which could be either a string or a
 // sequence of token ids.
 // Use `litert_lm_token_union_delete` to free memory.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmTokenUnion LiteRtLmTokenUnion;
 
 // Opaque pointer for LiteRT LM Token Unions.
 // Represents a collection of TokenUnion, typically used for model stop
 // conditions.
 // Use `litert_lm_token_unions_delete` to free memory.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmTokenUnions LiteRtLmTokenUnions;
 
 // Opaque pointer for LiteRT LM Input Data.
 // Use `litert_lm_input_data_delete` to free memory.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmInputData LiteRtLmInputData;
 
 // Opaque pointer for LiteRT LM Session Config.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmSessionConfig LiteRtLmSessionConfig;
 
 // Opaque pointer for LiteRT LM Conversation Config.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmConversationConfig LiteRtLmConversationConfig;
 
 // Represents the type of sampler.
+//
+// Added in version 0.1.0.
 typedef enum {
   // Probabilistically pick among the top k tokens.
   kLiteRtLmSamplerTypeTopK = 1,
@@ -111,6 +165,8 @@ typedef enum {
 
 // Opaque pointer for LiteRT LM Sampler Parameters.
 // Use `litert_lm_sampler_params_delete` to free memory.
+//
+// Added in version 0.1.0.
 typedef struct LiteRtLmSamplerParams LiteRtLmSamplerParams;
 
 // Creates LiteRT LM Sampler Parameters with a specific sampler type.
@@ -119,6 +175,8 @@ typedef struct LiteRtLmSamplerParams LiteRtLmSamplerParams;
 //
 // @param type The sampler type to use.
 // @return A pointer to the created parameters, or NULL on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmSamplerParams* litert_lm_sampler_params_create(
     LiteRtLmSamplerType type);
@@ -126,39 +184,69 @@ LiteRtLmSamplerParams* litert_lm_sampler_params_create(
 // Destroys LiteRT LM Sampler Parameters.
 //
 // @param params The parameters to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_sampler_params_delete(LiteRtLmSamplerParams* params);
 
 // Sets the top-k value.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_sampler_params_set_top_k(LiteRtLmSamplerParams* params,
                                         int32_t top_k);
 
 // Sets the top-p value.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_sampler_params_set_top_p(LiteRtLmSamplerParams* params,
                                         float top_p);
 
 // Sets the temperature.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_sampler_params_set_temperature(LiteRtLmSamplerParams* params,
                                               float temperature);
 
 // Sets the seed.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_sampler_params_set_seed(LiteRtLmSamplerParams* params,
                                        int32_t seed);
+
+// Represents the type of constraint for constrained decoding.
+//
+// Added in version 0.1.0.
+typedef enum {
+  kLiteRtLmConstraintTypeNone = 0,
+  kLiteRtLmConstraintTypeRegex = 1,
+  kLiteRtLmConstraintTypeJsonSchema = 2,
+} LiteRtLmConstraintType;
+
+// Represents the type of constraint provider.
+//
+// Added in version 0.1.0.
+typedef enum {
+  kLiteRtLmConstraintProviderTypeLlGuidance = 1,
+} LiteRtLmConstraintProviderType;
 
 // Creates a LiteRT LM Session Config.
 // The caller is responsible for destroying the config using
 // `litert_lm_session_config_delete`.
 // @return A pointer to the created config, or NULL on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmSessionConfig* litert_lm_session_config_create();
 
 // Sets the maximum number of output tokens per decode step for this session.
 // @param config The config to modify.
 // @param max_output_tokens The maximum number of output tokens.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_session_config_set_max_output_tokens(
     LiteRtLmSessionConfig* config, int max_output_tokens);
@@ -166,6 +254,8 @@ void litert_lm_session_config_set_max_output_tokens(
 // Sets whether to apply prompt template for this session.
 // @param config The config to modify.
 // @param apply_prompt_template Whether to apply prompt template.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_session_config_set_apply_prompt_template(
     LiteRtLmSessionConfig* config, bool apply_prompt_template);
@@ -173,12 +263,16 @@ void litert_lm_session_config_set_apply_prompt_template(
 // Sets the sampler parameters for this session config.
 // @param config The config to modify.
 // @param sampler_params The sampler parameters to use.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_session_config_set_sampler_params(
     LiteRtLmSessionConfig* config, const LiteRtLmSamplerParams* sampler_params);
 
 // Destroys a LiteRT LM Session Config.
 // @param config The config to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_session_config_delete(LiteRtLmSessionConfig* config);
 
@@ -186,6 +280,8 @@ void litert_lm_session_config_delete(LiteRtLmSessionConfig* config);
 // @param config The config to modify.
 // @param lora_path The path to the text LoRA weights file.
 // @return 0 on success, non-zero on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_session_config_set_lora_path(LiteRtLmSessionConfig* config,
                                            const char* lora_path);
@@ -194,6 +290,8 @@ int litert_lm_session_config_set_lora_path(LiteRtLmSessionConfig* config,
 // @param config The config to modify.
 // @param audio_lora_path The path to the audio LoRA weights file.
 // @return 0 on success, non-zero on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_session_config_set_audio_lora_path(LiteRtLmSessionConfig* config,
                                                  const char* audio_lora_path);
@@ -202,12 +300,16 @@ int litert_lm_session_config_set_audio_lora_path(LiteRtLmSessionConfig* config,
 // The caller is responsible for destroying the config using
 // `litert_lm_conversation_config_delete`.
 // @return A pointer to the created config, or NULL on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmConversationConfig* litert_lm_conversation_config_create();
 
 // Sets the session config for this conversation config.
 // @param config The config to modify.
 // @param session_config The session config to use.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_config_set_session_config(
     LiteRtLmConversationConfig* config,
@@ -216,6 +318,8 @@ void litert_lm_conversation_config_set_session_config(
 // Sets the system message for this conversation config.
 // @param config The config to modify.
 // @param system_message_json The system message in JSON format.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_config_set_system_message(
     LiteRtLmConversationConfig* config, const char* system_message_json);
@@ -223,6 +327,8 @@ void litert_lm_conversation_config_set_system_message(
 // Sets the tools for this conversation config.
 // @param config The config to modify.
 // @param tools_json The tools description in JSON array format.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_config_set_tools(LiteRtLmConversationConfig* config,
                                              const char* tools_json);
@@ -230,6 +336,8 @@ void litert_lm_conversation_config_set_tools(LiteRtLmConversationConfig* config,
 // Sets the initial messages for this conversation config.
 // @param config The config to modify.
 // @param messages_json The initial messages in JSON array format.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_config_set_messages(
     LiteRtLmConversationConfig* config, const char* messages_json);
@@ -238,21 +346,47 @@ void litert_lm_conversation_config_set_messages(
 // @param config The config to modify.
 // @param extra_context_json A JSON string representing the extra context
 // object.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_config_set_extra_context(
     LiteRtLmConversationConfig* config, const char* extra_context_json);
 
+// Sets the prompt template for this conversation config.
+// @param config The config to modify.
+// @param prompt_template The prompt template string (e.g. Jinja template). If
+// not set, use the default provided by the model or the engine.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_config_set_prompt_template(
+    LiteRtLmConversationConfig* config, const char* prompt_template);
+
 // Sets whether to enable constrained decoding for this conversation config.
 // @param config The config to modify.
 // @param enable_constrained_decoding Whether to enable constrained decoding.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_config_set_enable_constrained_decoding(
     LiteRtLmConversationConfig* config, bool enable_constrained_decoding);
+
+// Sets the constraint provider type for this conversation config.
+// @param config The config to modify.
+// @param provider_type The constraint provider type to use, or NULL to unset.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_config_set_constraint_provider(
+    LiteRtLmConversationConfig* config,
+    const LiteRtLmConstraintProviderType* provider_type);
 
 // Sets whether to filter channel content from the KV cache.
 // @param config The config to modify.
 // @param filter_channel_content_from_kv_cache Whether to filter channel
 // content.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_config_set_filter_channel_content_from_kv_cache(
     LiteRtLmConversationConfig* config,
@@ -262,32 +396,321 @@ void litert_lm_conversation_config_set_filter_channel_content_from_kv_cache(
 // @param config The config to modify.
 // @param stream_tool_calls Whether to stream tool call tokens.
 // @param channel_name The channel name to use for tool call tokens.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_config_set_stream_tool_calls(
     LiteRtLmConversationConfig* config, bool stream_tool_calls,
     const char* channel_name);
 
+// Creates a default LiteRT LM Thinking Config (enabled with infinite budget
+// -1). The caller is responsible for destroying the config using
+// `litert_lm_thinking_config_delete`.
+// @return A pointer to the created config, or NULL on failure.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+LiteRtLmThinkingConfig* litert_lm_thinking_config_create();
+
+// Destroys a LiteRT LM Thinking Config.
+// @param config The config to destroy.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_thinking_config_delete(LiteRtLmThinkingConfig* config);
+
+// Sets whether thinking/reasoning generation is enabled.
+// @param config The config to modify.
+// @param enable_thinking Whether thinking is enabled.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_thinking_config_set_enable_thinking(
+    LiteRtLmThinkingConfig* config, bool enable_thinking);
+
+// Sets the thinking token budget.
+// @param config The config to modify.
+// @param thinking_token_budget Budget for token-by-token reasoning generation
+// (-1 for infinite).
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_thinking_config_set_thinking_token_budget(
+    LiteRtLmThinkingConfig* config, int thinking_token_budget);
+
+// Sets the thinking config for this conversation config.
+// @param config The config to modify.
+// @param thinking_config The thinking config to set. If NULL, clears any
+// previously set thinking config.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_config_set_thinking_config(
+    LiteRtLmConversationConfig* config,
+    const LiteRtLmThinkingConfig* thinking_config);
+
 // Destroys a LiteRT LM Conversation Config.
 // @param config The config to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_config_delete(LiteRtLmConversationConfig* config);
+
+// Creates a LiteRT LM Repetition Penalty Config with default values
+// (`repetition_penalty` = 1.0f, `presence_penalty` = 0.0f,
+// `frequency_penalty` = 0.0f, `window_size` = 0, which means all history with
+// no penalties active).
+//
+// When multiple penalties are configured and active, the order of application
+// to output logits during decoding is:
+// 1. Multiplicative penalty (`repetition_penalty`)
+// 2. Subtractive penalties (`presence_penalty` and `frequency_penalty`)
+//
+// The caller is responsible for destroying the config using
+// `litert_lm_repetition_penalty_config_delete`.
+// @return A pointer to the created config, or NULL on failure.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+LiteRtLmRepetitionPenaltyConfig* litert_lm_repetition_penalty_config_create();
+
+// Destroys a LiteRT LM Repetition Penalty Config.
+// @param config The config to destroy.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_repetition_penalty_config_delete(
+    LiteRtLmRepetitionPenaltyConfig* config);
+
+// Sets the multiplicative repetition penalty for the repetition penalty config.
+// @param config The config to modify.
+// @param repetition_penalty A multiplicative penalty applied to a token's logit
+// if that token has appeared at least once inside the generated window history
+// (e.g., 1.0 = no penalty, 1.2 = moderate penalty). Positive logits are divided
+// by this parameter, and negative logits are multiplied (HuggingFace style).
+// The parameter must be >= 1.0f; values less than 1.0f are automatically
+// clamped to 1.0f during execution.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_repetition_penalty_config_set_repetition_penalty(
+    LiteRtLmRepetitionPenaltyConfig* config, float repetition_penalty);
+
+// Sets the subtractive presence penalty for the repetition penalty config.
+// @param config The config to modify.
+// @param presence_penalty A scalar subtracted from a token's logit if that
+// token has appeared at least once inside the generated window history.
+// Positive values discourage repetition, while negative values reward repeating
+// tokens (OpenAI style). Defaults to 0.0f.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_repetition_penalty_config_set_presence_penalty(
+    LiteRtLmRepetitionPenaltyConfig* config, float presence_penalty);
+
+// Sets the subtractive frequency penalty for the repetition penalty config.
+// @param config The config to modify.
+// @param frequency_penalty A scalar subtracted from a token's logit, scaled
+// linearly by the number of times that token has previously appeared inside the
+// generated window history. Positive values discourage repetition, while
+// negative values reward repeating tokens (OpenAI style). Defaults to 0.0f.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_repetition_penalty_config_set_frequency_penalty(
+    LiteRtLmRepetitionPenaltyConfig* config, float frequency_penalty);
+
+// Sets the window size for the repetition penalty config.
+// @param config The config to modify.
+// @param window_size The maximum number of recent tokens in generation history
+// to consider when computing penalization. Tokens generated prior to this
+// window are forgotten. A value of 0 means tracking all infinite generation
+// history. Must be >= 0; negative values are clamped to 0 during execution.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_repetition_penalty_config_set_window_size(
+    LiteRtLmRepetitionPenaltyConfig* config, int window_size);
+
+// Creates a LiteRT LM No Repeat Ngram Config with default values
+// (`no_repeat_ngram_size` = 0, `window_size` = 0, which means no repeat ngram
+// banning is disabled).
+//
+// When `no_repeat_ngram_size` is set greater than 0, any sequence of tokens (an
+// ngram of that exact length) generated during decoding or present inside the
+// window history can only occur at most once. If generating a candidate token
+// would complete a repeating ngram, that candidate token's logit is set to
+// -inf.
+//
+// The caller is responsible for destroying the config using
+// `litert_lm_no_repeat_ngram_config_delete`.
+// @return A pointer to the created config, or NULL on failure.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+LiteRtLmNoRepeatNgramConfig* litert_lm_no_repeat_ngram_config_create();
+
+// Destroys a LiteRT LM No Repeat Ngram Config.
+// @param config The config to destroy.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_no_repeat_ngram_config_delete(
+    LiteRtLmNoRepeatNgramConfig* config);
+
+// Sets the no repeat ngram size for the no repeat ngram config.
+// @param config The config to modify.
+// @param no_repeat_ngram_size The size of ngrams (consecutive token sequences)
+// that are banned from repeating within the generation history window. If set
+// > 0, when generating the next token would complete an already observed
+// `no_repeat_ngram_size` sequence, the logit of the candidate token is set to
+// -inf. If set <= 0, no repeat ngram banning is disabled. Negative values are
+// automatically clamped to 0 during execution.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_no_repeat_ngram_config_set_no_repeat_ngram_size(
+    LiteRtLmNoRepeatNgramConfig* config, int no_repeat_ngram_size);
+
+// Sets the window size for the no repeat ngram config.
+// @param config The config to modify.
+// @param window_size The maximum number of recent tokens in generation history
+// to consider when checking for repeating ngrams. Tokens generated prior to
+// this window are forgotten. A value of 0 means tracking all infinite
+// generation history. Must be >= 0; negative values are clamped to 0. If
+// `window_size` is greater than 0 but less than `no_repeat_ngram_size`, it is
+// automatically clamped to `no_repeat_ngram_size` so that the ngrams can fit
+// and be tracked.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_no_repeat_ngram_config_set_window_size(
+    LiteRtLmNoRepeatNgramConfig* config, int window_size);
+
+// Creates a LiteRT LM Suppress Tokens Config with default values (an empty set
+// of suppressed tokens, which means token suppression is disabled).
+//
+// When `suppress_tokens` is configured with one or more token IDs, the logits
+// corresponding to those exact token IDs will be set directly to -inf during
+// generation. This guarantees that those tokens can never be sampled by the
+// model.
+//
+// The caller is responsible for destroying the config using
+// `litert_lm_suppress_tokens_config_delete`.
+// @return A pointer to the created config, or NULL on failure.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+LiteRtLmSuppressTokensConfig* litert_lm_suppress_tokens_config_create();
+
+// Destroys a LiteRT LM Suppress Tokens Config.
+// @param config The config to destroy.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_suppress_tokens_config_delete(
+    LiteRtLmSuppressTokensConfig* config);
+
+// Sets the list of token IDs to suppress for the suppress tokens config.
+// @param config The config to modify.
+// @param suppress_tokens An array of integer token IDs that should be banned
+// from generation. During every decode step, each listed token ID's candidate
+// logit will be forced to -inf. If `suppress_tokens` is NULL or `num_tokens` is
+// 0, any previously set suppressed tokens are cleared and token suppression is
+// disabled.
+// @param num_tokens The number of token IDs in the `suppress_tokens` array.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_suppress_tokens_config_set_suppress_tokens(
+    LiteRtLmSuppressTokensConfig* config, const int* suppress_tokens,
+    size_t num_tokens);
 
 // Creates a LiteRT LM Conversation Optional Args. The caller is responsible
 // for destroying the optional args using
 // `litert_lm_conversation_optional_args_delete`.
 // @return A pointer to the created optional args, or NULL on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmConversationOptionalArgs* litert_lm_conversation_optional_args_create();
 
 // Destroys a LiteRT LM Conversation Optional Args.
 // @param optional_args The optional args to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_optional_args_delete(
     LiteRtLmConversationOptionalArgs* optional_args);
 
+// Sets the repetition penalty configuration for the per-turn conversation
+// optional arguments (`OptionalArgs`).
+//
+// The configured penalties (`repetition_penalty`, `presence_penalty`,
+// `frequency_penalty`, `window_size`) apply exclusively to the output sequence
+// generated during the current `send_message` or `send_message_async` call.
+//
+// @param optional_args The optional arguments structure (`OptionalArgs`) to
+// modify.
+// @param repetition_penalty_config The repetition penalty configuration struct
+// (`LiteRtLmRepetitionPenaltyConfig`) created via
+// `litert_lm_repetition_penalty_config_create`. The contents are deep-copied
+// when set. If NULL, clears any previously set repetition penalty config so no
+// penalties apply.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_optional_args_set_repetition_penalty_config(
+    LiteRtLmConversationOptionalArgs* optional_args,
+    const LiteRtLmRepetitionPenaltyConfig* repetition_penalty_config);
+
+// Sets the no repeat ngram configuration for the per-turn conversation
+// optional arguments (`OptionalArgs`).
+//
+// The configured parameters (`no_repeat_ngram_size`, `window_size`) apply
+// exclusively to the output sequence generated during the current
+// `send_message` or `send_message_async` call.
+//
+// @param optional_args The optional arguments structure (`OptionalArgs`) to
+// modify.
+// @param no_repeat_ngram_config The no repeat ngram configuration struct
+// (`LiteRtLmNoRepeatNgramConfig`) created via
+// `litert_lm_no_repeat_ngram_config_create`. The contents are deep-copied when
+// set. If NULL, clears any previously set no repeat ngram config so no
+// repeat ngram banning applies.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_optional_args_set_no_repeat_ngram_config(
+    LiteRtLmConversationOptionalArgs* optional_args,
+    const LiteRtLmNoRepeatNgramConfig* no_repeat_ngram_config);
+
+// Sets the suppress tokens configuration for the per-turn conversation
+// optional arguments (`OptionalArgs`).
+//
+// The configured list of suppressed tokens applies exclusively to the output
+// sequence generated during the current `send_message` or
+// `send_message_async` call.
+//
+// @param optional_args The optional arguments structure (`OptionalArgs`) to
+// modify.
+// @param suppress_tokens_config The suppress tokens configuration struct
+// (`LiteRtLmSuppressTokensConfig`) created via
+// `litert_lm_suppress_tokens_config_create`. The contents are deep-copied when
+// set. If NULL or if the inner token set is disabled/empty, clears any
+// previously set suppress tokens config so no token suppression applies.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_optional_args_set_suppress_tokens_config(
+    LiteRtLmConversationOptionalArgs* optional_args,
+    const LiteRtLmSuppressTokensConfig* suppress_tokens_config);
+
 // Sets the visual token budget for the conversation optional args.
 // @param optional_args The optional args to modify.
 // @param visual_token_budget The visual token budget.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_optional_args_set_visual_token_budget(
     LiteRtLmConversationOptionalArgs* optional_args, int visual_token_budget);
@@ -295,17 +718,54 @@ void litert_lm_conversation_optional_args_set_visual_token_budget(
 // Sets the maximum number of output tokens for the conversation optional args.
 // @param optional_args The optional args to modify.
 // @param max_output_tokens The maximum number of output tokens.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_optional_args_set_max_output_tokens(
     LiteRtLmConversationOptionalArgs* optional_args, int max_output_tokens);
 
-// Sets the minimum log level for the LiteRT LM library.
-// Log levels are: 0=VERBOSE, 1=DEBUG, 2=INFO, 3=WARNING, 4=ERROR, 5=FATAL,
-// 1000=SILENT.
+// Sets the thinking config for the conversation optional args.
+// @param optional_args The optional args to modify.
+// @param thinking_config The thinking config to set. If NULL, clears any
+// previously set thinking config.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
-void litert_lm_set_min_log_level(int level);
+void litert_lm_conversation_optional_args_set_thinking_config(
+    LiteRtLmConversationOptionalArgs* optional_args,
+    const LiteRtLmThinkingConfig* thinking_config);
+
+// Sets the constraint for the conversation optional args.
+// @param optional_args The optional args to modify.
+// @param constraint_type The type of constraint.
+// @param constraint_string The constraint pattern/schema/grammar string.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_optional_args_set_constraint(
+    LiteRtLmConversationOptionalArgs* optional_args,
+    LiteRtLmConstraintType constraint_type, const char* constraint_string);
+// Represents the log severity / level.
+//
+// Added in version 0.1.0.
+typedef enum {
+  kLiteRtLmLogSeverityVerbose = 0,
+  kLiteRtLmLogSeverityDebug = 1,
+  kLiteRtLmLogSeverityInfo = 2,
+  kLiteRtLmLogSeverityWarning = 3,
+  kLiteRtLmLogSeverityError = 4,
+  kLiteRtLmLogSeverityFatal = 5,
+  kLiteRtLmLogSeveritySilent = 1000,
+} LiteRtLmLogSeverity;
+// Sets the minimum log level for the LiteRT LM library.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_set_min_log_level(LiteRtLmLogSeverity level);
 
 // Represents the type of input data.
+//
+// Added in version 0.1.0.
 typedef enum {
   kLiteRtLmInputDataTypeText,
   kLiteRtLmInputDataTypeImage,
@@ -324,6 +784,8 @@ typedef enum {
 //             The data is copied internally.
 // @param size The size of the data in bytes.
 // @return A pointer to the created input data, or NULL on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmInputData* litert_lm_input_data_create(LiteRtLmInputDataType type,
                                                const void* data, size_t size);
@@ -331,6 +793,8 @@ LiteRtLmInputData* litert_lm_input_data_create(LiteRtLmInputDataType type,
 // Destroys a LiteRT LM Input Data.
 //
 // @param input_data The input data to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_input_data_delete(LiteRtLmInputData* input_data);
 
@@ -342,6 +806,8 @@ void litert_lm_input_data_delete(LiteRtLmInputData* input_data);
 // @param vision_backend_str The vision backend to use, or NULL if not set.
 // @param audio_backend_str The audio backend to use, or NULL if not set.
 // @return A pointer to the created settings, or NULL on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmEngineSettings* litert_lm_engine_settings_create(
     const char* model_path, const char* backend_str,
@@ -357,6 +823,8 @@ LiteRtLmEngineSettings* litert_lm_engine_settings_create(
 // @param vision_backend_str The vision backend to use, or NULL if not set.
 // @param audio_backend_str The audio backend to use, or NULL if not set.
 // @return A pointer to the created settings, or NULL on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmEngineSettings*
 litert_lm_engine_settings_create_from_raw_file_descriptor(
@@ -366,6 +834,8 @@ litert_lm_engine_settings_create_from_raw_file_descriptor(
 // Destroys LiteRT LM Engine Settings.
 //
 // @param settings The settings to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_delete(LiteRtLmEngineSettings* settings);
 
@@ -373,6 +843,8 @@ void litert_lm_engine_settings_delete(LiteRtLmEngineSettings* settings);
 //
 // @param settings The engine settings.
 // @param max_num_tokens The maximum number of tokens.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_max_num_tokens(
     LiteRtLmEngineSettings* settings, int max_num_tokens);
@@ -381,6 +853,8 @@ void litert_lm_engine_settings_set_max_num_tokens(
 //
 // @param settings The engine settings.
 // @param num_threads The number of threads.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_num_threads(LiteRtLmEngineSettings* settings,
                                                int num_threads);
@@ -389,6 +863,8 @@ void litert_lm_engine_settings_set_num_threads(LiteRtLmEngineSettings* settings,
 //
 // @param settings The engine settings.
 // @param num_threads The number of threads.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_audio_num_threads(
     LiteRtLmEngineSettings* settings, int num_threads);
@@ -398,6 +874,8 @@ void litert_lm_engine_settings_set_audio_num_threads(
 //
 // @param settings The engine settings.
 // @param parallel_file_section_loading Whether to load in parallel.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_parallel_file_section_loading(
     LiteRtLmEngineSettings* settings, bool parallel_file_section_loading);
@@ -408,6 +886,8 @@ void litert_lm_engine_settings_set_parallel_file_section_loading(
 //
 // @param settings The engine settings.
 // @param max_num_images The maximum number of images.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_max_num_images(
     LiteRtLmEngineSettings* settings, int max_num_images);
@@ -416,6 +896,8 @@ void litert_lm_engine_settings_set_max_num_images(
 //
 // @param settings The engine settings.
 // @param cache_dir The cache directory.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_cache_dir(LiteRtLmEngineSettings* settings,
                                              const char* cache_dir);
@@ -424,25 +906,40 @@ void litert_lm_engine_settings_set_cache_dir(LiteRtLmEngineSettings* settings,
 //
 // @param settings The engine settings.
 // @param lib_dir The dispatch library directory.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_litert_dispatch_lib_dir(
     LiteRtLmEngineSettings* settings, const char* lib_dir);
 
+// Represents the activation data type.
+//
+// Added in version 0.1.0.
+typedef enum {
+  kLiteRtLmActivationDataTypeFloat32 = 0,
+  kLiteRtLmActivationDataTypeFloat16 = 1,
+  kLiteRtLmActivationDataTypeInt16 = 2,
+  kLiteRtLmActivationDataTypeInt8 = 3,
+} LiteRtLmActivationDataType;
+
 // Sets the activation data type.
 //
 // @param settings The engine settings.
-// @param activation_data_type_int The activation data type. See
-// `ActivationDataType` in executor_settings_base.h for the possible values
-// (e.g., 0 for F32, 1 for F16, 2 for I16, 3 for I8).
+// @param activation_data_type The activation data type.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_activation_data_type(
-    LiteRtLmEngineSettings* settings, int activation_data_type_int);
+    LiteRtLmEngineSettings* settings,
+    LiteRtLmActivationDataType activation_data_type);
 
 // Sets the prefill chunk size for the engine. Only applicable for CPU backend
 // with dynamic models.
 //
 // @param settings The engine settings.
 // @param prefill_chunk_size The prefill chunk size.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_prefill_chunk_size(
     LiteRtLmEngineSettings* settings, int prefill_chunk_size);
@@ -450,6 +947,8 @@ void litert_lm_engine_settings_set_prefill_chunk_size(
 // Enables benchmarking for the engine.
 //
 // @param settings The engine settings.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_enable_benchmark(
     LiteRtLmEngineSettings* settings);
@@ -458,6 +957,8 @@ void litert_lm_engine_settings_enable_benchmark(
 //
 // @param settings The engine settings.
 // @param num_prefill_tokens The number of prefill tokens.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_num_prefill_tokens(
     LiteRtLmEngineSettings* settings, int num_prefill_tokens);
@@ -466,6 +967,8 @@ void litert_lm_engine_settings_set_num_prefill_tokens(
 //
 // @param settings The engine settings.
 // @param num_decode_tokens The number of decode tokens.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_num_decode_tokens(
     LiteRtLmEngineSettings* settings, int num_decode_tokens);
@@ -474,14 +977,61 @@ void litert_lm_engine_settings_set_num_decode_tokens(
 //
 // @param settings The engine settings.
 // @param enable_speculative_decoding Whether to enable speculative decoding.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_enable_speculative_decoding(
     LiteRtLmEngineSettings* settings, bool enable_speculative_decoding);
+
+// Sets the number of decode steps per sync for the GPU backend.
+// Note: This setting is currently only supported for the Artisan GPU
+// backend (Artisan).
+//
+// @param settings The engine settings.
+// @param num_decode_steps_per_sync The number of decode steps per sync.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_engine_settings_set_gpu_decode_steps_per_sync(
+    LiteRtLmEngineSettings* settings, int num_decode_steps_per_sync);
+
+// Sets whether to wait for weight uploads for the GPU backend.
+// Note: This setting is currently only supported for the Artisan GPU backend.
+//
+// @param settings The engine settings.
+// @param wait_for_weight_uploads Whether to wait for weight uploads.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_engine_settings_set_gpu_wait_for_weight_uploads(
+    LiteRtLmEngineSettings* settings, bool wait_for_weight_uploads);
+
+// Sets whether to use ringbuffers for local attention KV cache.
+//
+// When enabled for supported models, a ringbuffer stores only necessary KV
+// cache memory for local attention layers, minimizing memory usage. When
+// disabled, memory is allocated for the full context length, enabling instant
+// rewinding at the cost of higher memory usage.
+//
+// Note: This feature is backend-agnostic in interface design, but currently
+// only supported by the GPU Artisan backend. Enabling it on unsupported models
+// or backends will be ignored with a warning.
+//
+// @param settings The engine settings.
+// @param use_ringbuffers_local_attention Whether to use ringbuffers for local
+// attention.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_engine_settings_set_use_ringbuffers_local_attention(
+    LiteRtLmEngineSettings* settings, bool use_ringbuffers_local_attention);
 
 // Sets the LoRA rank for the engine.
 //
 // @param settings The engine settings.
 // @param lora_rank The LoRA rank.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_lora_rank(LiteRtLmEngineSettings* settings,
                                              int lora_rank);
@@ -492,6 +1042,8 @@ void litert_lm_engine_settings_set_lora_rank(LiteRtLmEngineSettings* settings,
 // @param lora_ranks An array of supported LoRA ranks.
 // @param num_ranks The number of ranks in the array.
 // @return 0 on success, non-zero on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_engine_settings_set_supported_lora_ranks(
     LiteRtLmEngineSettings* settings, const int* lora_ranks, size_t num_ranks);
@@ -500,6 +1052,8 @@ int litert_lm_engine_settings_set_supported_lora_ranks(
 //
 // @param settings The engine settings.
 // @param lora_rank The Audio LoRA rank.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_audio_lora_rank(
     LiteRtLmEngineSettings* settings, int lora_rank);
@@ -510,6 +1064,8 @@ void litert_lm_engine_settings_set_audio_lora_rank(
 // @param lora_ranks An array of supported Audio LoRA ranks.
 // @param num_ranks The number of ranks in the array.
 // @return 0 on success, non-zero on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_engine_settings_set_supported_audio_lora_ranks(
     LiteRtLmEngineSettings* settings, const int* lora_ranks, size_t num_ranks);
@@ -519,12 +1075,16 @@ int litert_lm_engine_settings_set_supported_audio_lora_ranks(
 //
 // @param settings The engine settings.
 // @return A pointer to the created engine, or NULL on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmEngine* litert_lm_engine_create(const LiteRtLmEngineSettings* settings);
 
 // Destroys a LiteRT LM Engine.
 //
 // @param engine The engine to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_delete(LiteRtLmEngine* engine);
 
@@ -535,6 +1095,8 @@ void litert_lm_engine_delete(LiteRtLmEngine* engine);
 // @param config The session config of the session. If NULL, use the default
 // session config.
 // @return A pointer to the created session, or NULL on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmSession* litert_lm_engine_create_session(LiteRtLmEngine* engine,
                                                  LiteRtLmSessionConfig* config);
@@ -542,12 +1104,16 @@ LiteRtLmSession* litert_lm_engine_create_session(LiteRtLmEngine* engine,
 // Destroys a LiteRT LM Session.
 //
 // @param session The session to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_session_delete(LiteRtLmSession* session);
 
 // Cancels the current processing in the session.
 //
 // @param session The session to cancel processing on.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_session_cancel_process(LiteRtLmSession* session);
 
@@ -560,6 +1126,8 @@ void litert_lm_session_cancel_process(LiteRtLmSession* session);
 //   input.
 // @param num_inputs The number of InputData structs in the array.
 // @return 0 on success, non-zero on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_session_run_prefill(LiteRtLmSession* session,
                                   const LiteRtLmInputData* const* inputs,
@@ -573,6 +1141,8 @@ int litert_lm_session_run_prefill(LiteRtLmSession* session,
 // @param session The session to use.
 // @return A pointer to the responses, or NULL on failure. The caller is
 //   responsible for deleting the responses using `litert_lm_responses_delete`.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmResponses* litert_lm_session_run_decode(LiteRtLmSession* session);
 
@@ -585,6 +1155,8 @@ LiteRtLmResponses* litert_lm_session_run_decode(LiteRtLmSession* session);
 //   texts in the responses.
 // @return A pointer to the responses, or NULL on failure. The caller is
 //   responsible for deleting the responses using `litert_lm_responses_delete`.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmResponses* litert_lm_session_run_text_scoring(LiteRtLmSession* session,
                                                       const char** target_text,
@@ -600,6 +1172,8 @@ LiteRtLmResponses* litert_lm_session_run_text_scoring(LiteRtLmSession* session,
 // @param num_inputs The number of LiteRtLmInputData structs in the array.
 // @return A pointer to the responses, or NULL on failure. The caller is
 //   responsible for deleting the responses using `litert_lm_responses_delete`.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmResponses* litert_lm_session_generate_content(
     LiteRtLmSession* session, const LiteRtLmInputData* const* inputs,
@@ -607,6 +1181,8 @@ LiteRtLmResponses* litert_lm_session_generate_content(
 // Destroys a LiteRT LM Responses object.
 //
 // @param responses The responses to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_responses_delete(LiteRtLmResponses* responses);
 
@@ -614,6 +1190,8 @@ void litert_lm_responses_delete(LiteRtLmResponses* responses);
 //
 // @param responses The responses object.
 // @return The number of candidates.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_responses_get_num_candidates(const LiteRtLmResponses* responses);
 
@@ -624,6 +1202,8 @@ int litert_lm_responses_get_num_candidates(const LiteRtLmResponses* responses);
 // @return The response text. The returned string is owned by the `responses`
 //   object and is valid only for its lifetime. Returns NULL if index is out of
 //   bounds.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 const char* litert_lm_responses_get_response_text_at(
     const LiteRtLmResponses* responses, int index);
@@ -633,6 +1213,8 @@ const char* litert_lm_responses_get_response_text_at(
 // @param responses The responses object.
 // @param index The index of the response.
 // @return true if the score is available at the given index, false otherwise.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 bool litert_lm_responses_has_score_at(const LiteRtLmResponses* responses,
                                       int index);
@@ -643,6 +1225,8 @@ bool litert_lm_responses_has_score_at(const LiteRtLmResponses* responses,
 // @param index The index of the response.
 // @return The score. Returns 0.0f if index is out of bounds or no score is
 //   present.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 float litert_lm_responses_get_score_at(const LiteRtLmResponses* responses,
                                        int index);
@@ -653,6 +1237,8 @@ float litert_lm_responses_get_score_at(const LiteRtLmResponses* responses,
 // @param index The index of the response.
 // @return true if the token length is available at the given index, false
 //   otherwise.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 bool litert_lm_responses_has_token_length_at(const LiteRtLmResponses* responses,
                                              int index);
@@ -663,6 +1249,8 @@ bool litert_lm_responses_has_token_length_at(const LiteRtLmResponses* responses,
 // @param index The index of the response.
 // @return The token length. Returns 0 if index is out of bounds or no token
 //   length is present.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_responses_get_token_length_at(const LiteRtLmResponses* responses,
                                             int index);
@@ -673,6 +1261,8 @@ int litert_lm_responses_get_token_length_at(const LiteRtLmResponses* responses,
 // @param index The index of the response.
 // @return true if token scores are available at the given index, false
 // otherwise.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 bool litert_lm_responses_has_token_scores_at(const LiteRtLmResponses* responses,
                                              int index);
@@ -683,6 +1273,8 @@ bool litert_lm_responses_has_token_scores_at(const LiteRtLmResponses* responses,
 // @param index The index of the response.
 // @return The number of token scores. Returns 0 if index is out of bounds or no
 //   token scores are present.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_responses_get_num_token_scores_at(
     const LiteRtLmResponses* responses, int index);
@@ -694,6 +1286,8 @@ int litert_lm_responses_get_num_token_scores_at(
 // @return A pointer to the internal array of token scores. Returns NULL if
 // index
 //   is out of bounds or no token scores are present.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 const float* litert_lm_responses_get_token_scores_at(
     const LiteRtLmResponses* responses, int index);
@@ -704,6 +1298,8 @@ const float* litert_lm_responses_get_token_scores_at(
 //
 // @param session The session to get the benchmark info from.
 // @return A pointer to the benchmark info, or NULL on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmBenchmarkInfo* litert_lm_session_get_benchmark_info(
     LiteRtLmSession* session);
@@ -711,6 +1307,8 @@ LiteRtLmBenchmarkInfo* litert_lm_session_get_benchmark_info(
 // Destroys a LiteRT LM Benchmark Info object.
 //
 // @param benchmark_info The benchmark info to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_benchmark_info_delete(LiteRtLmBenchmarkInfo* benchmark_info);
 
@@ -722,6 +1320,8 @@ void litert_lm_benchmark_info_delete(LiteRtLmBenchmarkInfo* benchmark_info);
 //
 // @param benchmark_info The benchmark info object.
 // @return The time to the first token in seconds.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 double litert_lm_benchmark_info_get_time_to_first_token(
     const LiteRtLmBenchmarkInfo* benchmark_info);
@@ -730,6 +1330,8 @@ double litert_lm_benchmark_info_get_time_to_first_token(
 //
 // @param benchmark_info The benchmark info object.
 // @return The total initialization time in seconds.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 double litert_lm_benchmark_info_get_total_init_time_in_second(
     const LiteRtLmBenchmarkInfo* benchmark_info);
@@ -738,6 +1340,8 @@ double litert_lm_benchmark_info_get_total_init_time_in_second(
 //
 // @param benchmark_info The benchmark info object.
 // @return The number of prefill turns.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_benchmark_info_get_num_prefill_turns(
     const LiteRtLmBenchmarkInfo* benchmark_info);
@@ -746,6 +1350,8 @@ int litert_lm_benchmark_info_get_num_prefill_turns(
 //
 // @param benchmark_info The benchmark info object.
 // @return The number of decode turns.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_benchmark_info_get_num_decode_turns(
     const LiteRtLmBenchmarkInfo* benchmark_info);
@@ -755,6 +1361,8 @@ int litert_lm_benchmark_info_get_num_decode_turns(
 // @param benchmark_info The benchmark info object.
 // @param index The index of the prefill turn.
 // @return The prefill token count.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_benchmark_info_get_prefill_token_count_at(
     const LiteRtLmBenchmarkInfo* benchmark_info, int index);
@@ -764,6 +1372,8 @@ int litert_lm_benchmark_info_get_prefill_token_count_at(
 // @param benchmark_info The benchmark info object.
 // @param index The index of the decode turn.
 // @return The decode token count.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_benchmark_info_get_decode_token_count_at(
     const LiteRtLmBenchmarkInfo* benchmark_info, int index);
@@ -773,6 +1383,8 @@ int litert_lm_benchmark_info_get_decode_token_count_at(
 // @param benchmark_info The benchmark info object.
 // @param index The index of the prefill turn.
 // @return The prefill tokens per second.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 double litert_lm_benchmark_info_get_prefill_tokens_per_sec_at(
     const LiteRtLmBenchmarkInfo* benchmark_info, int index);
@@ -782,18 +1394,50 @@ double litert_lm_benchmark_info_get_prefill_tokens_per_sec_at(
 // @param benchmark_info The benchmark info object.
 // @param index The index of the decode turn.
 // @return The decode tokens per second.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 double litert_lm_benchmark_info_get_decode_tokens_per_sec_at(
     const LiteRtLmBenchmarkInfo* benchmark_info, int index);
 
+// Opaque pointer for LiteRT LM Stream Chunk.
+// This object represents a single chunk of data returned during streaming.
+// It is owned by the library and is only valid for the duration of the
+// callback.
+//
+// Added in version 0.1.0.
+typedef struct LiteRtLmStreamChunk LiteRtLmStreamChunk;
+
+// Gets the text content of the chunk.
+// The returned string is owned by the chunk and is only valid as long as the
+// chunk is valid. Returns NULL if there is no text content in this chunk (e.g.
+// if it is an error or metadata-only chunk).
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+const char* litert_lm_stream_chunk_get_text(const LiteRtLmStreamChunk* chunk);
+
+// Returns true if this is the final chunk of the stream.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+bool litert_lm_stream_chunk_is_final(const LiteRtLmStreamChunk* chunk);
+
+// Gets the error message associated with this chunk, if any.
+// Returns NULL if there is no error.
+//
+// Added in version 0.1.0.
+LITERT_LM_C_API_EXPORT
+const char* litert_lm_stream_chunk_get_error(const LiteRtLmStreamChunk* chunk);
+
 // Callback for streaming responses.
 // `callback_data` is a pointer to user-defined data passed to the stream
-// function. `chunk` is the piece of text from the stream. It's only valid for
-// the duration of the call. `is_final` is true if this is the last chunk in the
-// stream. `error_msg` is a null-terminated string with an error message, or
-// NULL on success.
-typedef void (*LiteRtLmStreamCallback)(void* callback_data, const char* chunk,
-                                       bool is_final, const char* error_msg);
+// function. `chunk` is a pointer to the stream chunk object. It's only valid
+// for the duration of the call.
+//
+// Added in version 0.1.0.
+typedef void (*LiteRtLmStreamCallback)(void* callback_data,
+                                       const LiteRtLmStreamChunk* chunk);
 
 // Starts the decoding process for the model to predict the response based
 // on the input prompt/query added after using litert_lm_session_run_prefill.
@@ -804,6 +1448,8 @@ typedef void (*LiteRtLmStreamCallback)(void* callback_data, const char* chunk,
 // @param callback_data A pointer to user data that will be passed to the
 // callback.
 // @return 0 on success, non-zero on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_session_run_decode_async(LiteRtLmSession* session,
                                        LiteRtLmStreamCallback callback,
@@ -822,6 +1468,8 @@ int litert_lm_session_run_decode_async(LiteRtLmSession* session,
 // @param callback_data A pointer to user data that will be passed to the
 // callback.
 // @return 0 on success, non-zero on failure to start the stream.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_session_generate_content_stream(
     LiteRtLmSession* session, const LiteRtLmInputData* const* inputs,
@@ -834,6 +1482,8 @@ int litert_lm_session_generate_content_stream(
 // @param config The conversation config to use. If NULL, the default config
 //   will be used.
 // @return A pointer to the created conversation, or NULL on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmConversation* litert_lm_conversation_create(
     LiteRtLmEngine* engine, LiteRtLmConversationConfig* config);
@@ -841,6 +1491,8 @@ LiteRtLmConversation* litert_lm_conversation_create(
 // Destroys a LiteRT LM Conversation.
 //
 // @param conversation The conversation to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_delete(LiteRtLmConversation* conversation);
 
@@ -850,6 +1502,8 @@ void litert_lm_conversation_delete(LiteRtLmConversation* conversation);
 //
 // @param conversation The conversation to clone.
 // @return A pointer to the cloned conversation, or NULL on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmConversation* litert_lm_conversation_clone(
     LiteRtLmConversation* conversation);
@@ -864,6 +1518,8 @@ LiteRtLmConversation* litert_lm_conversation_clone(
 // @return A pointer to the JSON response, or NULL on failure. The caller is
 //   responsible for deleting the response using
 //   `litert_lm_json_response_delete`.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmJsonResponse* litert_lm_conversation_send_message(
     LiteRtLmConversation* conversation, const char* message_json,
@@ -873,6 +1529,8 @@ LiteRtLmJsonResponse* litert_lm_conversation_send_message(
 // Destroys a LiteRT LM Json Response object.
 //
 // @param response The response to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_json_response_delete(LiteRtLmJsonResponse* response);
 
@@ -882,6 +1540,8 @@ void litert_lm_json_response_delete(LiteRtLmJsonResponse* response);
 // @return The response JSON string. The returned string is owned by the
 //   `response` object and is valid only for its lifetime. Returns NULL if
 //   response is NULL.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 const char* litert_lm_json_response_get_string(
     const LiteRtLmJsonResponse* response);
@@ -898,6 +1558,8 @@ const char* litert_lm_json_response_get_string(
 // @param callback_data A pointer to user data that will be passed to the
 // callback.
 // @return 0 on success, non-zero on failure to start the stream.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_conversation_send_message_stream(
     LiteRtLmConversation* conversation, const char* message_json,
@@ -917,6 +1579,8 @@ int litert_lm_conversation_send_message_stream(
 // @return A pointer to the rendered string, or NULL on failure. The returned
 //   string is owned by the `conversation` object and is valid until the next
 //   call to this function or until the conversation is deleted.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 const char* litert_lm_conversation_render_message_to_string(
     LiteRtLmConversation* conversation, const char* message_json);
@@ -927,6 +1591,8 @@ const char* litert_lm_conversation_render_message_to_string(
 // @return A pointer to the rendered string, or NULL on failure. The returned
 //   string is owned by the `conversation` object and is valid until the next
 //   call to this function or until the conversation is deleted.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 const char* litert_lm_conversation_render_preface_to_string(
     LiteRtLmConversation* conversation);
@@ -934,6 +1600,8 @@ const char* litert_lm_conversation_render_preface_to_string(
 // Cancels the ongoing inference process, for asynchronous inference.
 //
 // @param conversation The conversation to cancel the inference for.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_cancel_process(LiteRtLmConversation* conversation);
 
@@ -943,12 +1611,16 @@ void litert_lm_conversation_cancel_process(LiteRtLmConversation* conversation);
 //
 // @param conversation The conversation to get the benchmark info from.
 // @return A pointer to the benchmark info, or NULL on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmBenchmarkInfo* litert_lm_conversation_get_benchmark_info(
     LiteRtLmConversation* conversation);
 
 // Gets the number of tokens in the conversation KV Cache (prefill + decode).
 // Returns the number of tokens, or a negative value on failure.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_conversation_get_token_count(LiteRtLmConversation* conversation);
 
@@ -959,6 +1631,8 @@ int litert_lm_conversation_get_token_count(LiteRtLmConversation* conversation);
 // @return A pointer to the tokenize result, or NULL on failure.
 //   The caller is responsible for deleting the result using
 //   `litert_lm_tokenize_result_delete`.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmTokenizeResult* litert_lm_engine_tokenize(LiteRtLmEngine* engine,
                                                   const char* text);
@@ -966,6 +1640,8 @@ LiteRtLmTokenizeResult* litert_lm_engine_tokenize(LiteRtLmEngine* engine,
 // Destroys a LiteRT LM Tokenize Result.
 //
 // @param result The tokenize result to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_tokenize_result_delete(LiteRtLmTokenizeResult* result);
 
@@ -974,6 +1650,8 @@ void litert_lm_tokenize_result_delete(LiteRtLmTokenizeResult* result);
 // @param result The tokenize result.
 // @return A pointer to the internal array of token ids. The returned pointer
 //   is valid only for the lifetime of the `result` object.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 const int* litert_lm_tokenize_result_get_tokens(
     const LiteRtLmTokenizeResult* result);
@@ -982,6 +1660,8 @@ const int* litert_lm_tokenize_result_get_tokens(
 //
 // @param result The tokenize result.
 // @return The number of token ids.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 size_t litert_lm_tokenize_result_get_num_tokens(
     const LiteRtLmTokenizeResult* result);
@@ -994,6 +1674,8 @@ size_t litert_lm_tokenize_result_get_num_tokens(
 // @return A pointer to the detokenize result, or NULL on failure.
 //   The caller is responsible for deleting the result using
 //   `litert_lm_detokenize_result_delete`.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmDetokenizeResult* litert_lm_engine_detokenize(LiteRtLmEngine* engine,
                                                       const int* tokens,
@@ -1002,6 +1684,8 @@ LiteRtLmDetokenizeResult* litert_lm_engine_detokenize(LiteRtLmEngine* engine,
 // Destroys a LiteRT LM Detokenize Result.
 //
 // @param result The detokenize result to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_detokenize_result_delete(LiteRtLmDetokenizeResult* result);
 
@@ -1010,6 +1694,8 @@ void litert_lm_detokenize_result_delete(LiteRtLmDetokenizeResult* result);
 // @param result The detokenize result.
 // @return The detokenized UTF-8 string. The returned string is owned by the
 //   `result` object and is valid only for its lifetime.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 const char* litert_lm_detokenize_result_get_string(
     const LiteRtLmDetokenizeResult* result);
@@ -1017,6 +1703,8 @@ const char* litert_lm_detokenize_result_get_string(
 // Destroys a LiteRT LM Token Union.
 //
 // @param token_union The token union to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_token_union_delete(LiteRtLmTokenUnion* token_union);
 
@@ -1024,6 +1712,8 @@ void litert_lm_token_union_delete(LiteRtLmTokenUnion* token_union);
 //
 // @param token_union The token union.
 // @return The type of the token union.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmTokenUnionType litert_lm_token_union_get_type(
     const LiteRtLmTokenUnion* token_union);
@@ -1034,6 +1724,8 @@ LiteRtLmTokenUnionType litert_lm_token_union_get_type(
 // @return The string value, or NULL if the type is not
 //   kLiteRtLmTokenUnionTypeString. The returned string is owned by the
 //   `token_union` object and is valid only for its lifetime.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 const char* litert_lm_token_union_get_string(
     const LiteRtLmTokenUnion* token_union);
@@ -1046,6 +1738,8 @@ const char* litert_lm_token_union_get_string(
 //   object.
 // @param out_num_tokens A pointer to receive the number of token ids.
 // @return 0 on success, non-zero if the type is not kLiteRtLmTokenUnionTypeIds.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 int litert_lm_token_union_get_ids(const LiteRtLmTokenUnion* token_union,
                                   const int** out_tokens,
@@ -1054,6 +1748,8 @@ int litert_lm_token_union_get_ids(const LiteRtLmTokenUnion* token_union,
 // Destroys a LiteRT LM Token Unions object.
 //
 // @param tokens The token unions object to destroy.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 void litert_lm_token_unions_delete(LiteRtLmTokenUnions* tokens);
 
@@ -1061,6 +1757,8 @@ void litert_lm_token_unions_delete(LiteRtLmTokenUnions* tokens);
 //
 // @param tokens The token unions object.
 // @return The number of token unions.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 size_t litert_lm_token_unions_get_num_tokens(const LiteRtLmTokenUnions* tokens);
 
@@ -1071,6 +1769,8 @@ size_t litert_lm_token_unions_get_num_tokens(const LiteRtLmTokenUnions* tokens);
 // @return A pointer to the token union at the given index, or NULL if the index
 //   is out of bounds. The caller is responsible for deleting the result using
 //   `litert_lm_token_union_delete`.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmTokenUnion* litert_lm_token_unions_get_token_at(
     const LiteRtLmTokenUnions* tokens, size_t index);
@@ -1081,6 +1781,8 @@ LiteRtLmTokenUnion* litert_lm_token_unions_get_token_at(
 // @return A pointer to the start token, or NULL if none configured. The caller
 //   is responsible for deleting the result using
 //   `litert_lm_token_union_delete`.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmTokenUnion* litert_lm_engine_get_start_token(LiteRtLmEngine* engine);
 
@@ -1090,6 +1792,8 @@ LiteRtLmTokenUnion* litert_lm_engine_get_start_token(LiteRtLmEngine* engine);
 // @return A pointer to the stop tokens collection, or NULL if none configured.
 //   The caller is responsible for deleting the result using
 //   `litert_lm_token_unions_delete`.
+//
+// Added in version 0.1.0.
 LITERT_LM_C_API_EXPORT
 LiteRtLmTokenUnions* litert_lm_engine_get_stop_tokens(LiteRtLmEngine* engine);
 

--- a/ios/HybridLiteRTLM+Streaming.swift
+++ b/ios/HybridLiteRTLM+Streaming.swift
@@ -65,11 +65,14 @@ extension HybridLiteRTLM {
         )
         let ptr = Unmanaged.passRetained(ctx).toOpaque()
 
-        let cb: LiteRtLmStreamCallback = { ptr, chunk, isFinal, errorMsg in
-            guard let ptr = ptr else { return }
+        // v0.15: the callback receives an opaque LiteRtLmStreamChunk; text,
+        // finality, and errors are read through accessors. The chunk (and any
+        // string it returns) is only valid for the duration of the call.
+        let cb: LiteRtLmStreamCallback = { ptr, chunk in
+            guard let ptr = ptr, let chunk = chunk else { return }
             let ctx = Unmanaged<ExecuteStreamContext>.fromOpaque(ptr).takeUnretainedValue()
 
-            if let errorMsg = errorMsg {
+            if let errorMsg = litert_lm_stream_chunk_get_error(chunk) {
                 let msg = String(cString: errorMsg)
                 ctx.onToken("Error: \(msg)", true)
                 ctx.cleanup()
@@ -79,13 +82,13 @@ extension HybridLiteRTLM {
                 return
             }
 
-            if isFinal {
+            if litert_lm_stream_chunk_is_final(chunk) {
                 ctx.parent.finalizeExecuteStream(ctx: ctx, streamPtr: ptr)
                 return
             }
 
-            if let chunk = chunk {
-                ctx.parent.emitExecuteStreamChunk(ctx: ctx, chunk: chunk)
+            if let text = litert_lm_stream_chunk_get_text(chunk) {
+                ctx.parent.emitExecuteStreamChunk(ctx: ctx, chunk: text)
             }
         }
 

--- a/ios/HybridLiteRTLM.swift
+++ b/ios/HybridLiteRTLM.swift
@@ -286,8 +286,10 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
             
             var rawEngine: OpaquePointer? = nil
             
-            // Set LiteRT C Log Level to WARNING (2) for clean production output
-            litert_lm_set_min_log_level(2)
+            // Set LiteRT C Log Level to WARNING for clean production output.
+            // v0.15: takes a typed LiteRtLmLogSeverity (previously a raw int,
+            // where 2 was INFO — WARNING is the intended level).
+            litert_lm_set_min_log_level(kLiteRtLmLogSeverityWarning)
             
             // Creation helper with scoped FFI pointer lifetime
             let createEngine = { (main: String, vision: String?, audio: String?) -> OpaquePointer? in
@@ -315,8 +317,16 @@ public class HybridLiteRTLM: HybridLiteRTLMSpec_base, HybridLiteRTLMSpec_protoco
                     litert_lm_engine_settings_set_prefill_chunk_size(s, Int32(chunk))
                 }
                 if let adt = self.activationDataType {
-                    // Enum raw values match the C API: 0=F32, 1=F16, 2=I16, 3=I8
-                    litert_lm_engine_settings_set_activation_data_type(s, Int32(adt.rawValue))
+                    // v0.15: takes a typed LiteRtLmActivationDataType (raw values
+                    // unchanged: 0=F32, 1=F16, 2=I16, 3=I8)
+                    let cType: LiteRtLmActivationDataType
+                    switch adt.rawValue {
+                    case 1: cType = kLiteRtLmActivationDataTypeFloat16
+                    case 2: cType = kLiteRtLmActivationDataTypeInt16
+                    case 3: cType = kLiteRtLmActivationDataTypeInt8
+                    default: cType = kLiteRtLmActivationDataTypeFloat32
+                    }
+                    litert_lm_engine_settings_set_activation_data_type(s, cType)
                 }
                 if let rank = self.loraRank {
                     litert_lm_engine_settings_set_lora_rank(s, Int32(rank))

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "react-native-litert-lm",
   "version": "0.5.1",
   "litertLm": {
-    "version": "0.14.0",
-    "androidMavenVersion": "0.14.0",
-    "iosGitTag": "v0.14.0"
+    "version": "0.15.0",
+    "androidMavenVersion": "0.15.0",
+    "iosGitTag": "v0.15.0"
   },
   "description": "High-performance LLM inference for React Native using LiteRT-LM. Optimized for Gemma 4 and other on-device language models.",
   "license": "MIT",

--- a/react-native-litert-lm.podspec
+++ b/react-native-litert-lm.podspec
@@ -37,6 +37,10 @@ Pod::Spec.new do |s|
       '"$(PODS_TARGET_SRCROOT)/nitrogen/generated/ios"',
     ].join(' '),
     'OTHER_LDFLAGS' => '$(inherited) -ObjC',
+    # CLiteRTLM.xcframework has no x86_64 simulator slice (ARM-only policy);
+    # without this, generic simulator builds compile both archs and the
+    # CLiteRTLM module resolves for neither.
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'x86_64',
   }
 
   # Load nitrogen autolinking


### PR DESCRIPTION
Upgrades the engine pin **0.14.0 → 0.15.0** (upstream release 2026-08-04). PR 1 of the 0.15.0 plan — core upgrade only; structured output, thinking/sampler controls, and multi-conversation follow in separate PRs.

## Changes

- **Pins**: `litertLm.version` / `androidMavenVersion` / `iosGitTag` → 0.15.0. Asset verified on the upstream release; AAR live on Google Maven.
- **iOS — the three breaking C API changes** (complete set, confirmed by full `c/engine.h` diff):
  1. Streaming callback → opaque `LiteRtLmStreamChunk` + accessors; rewritten preserving error → final → text ordering
  2. `litert_lm_set_min_log_level` → typed `LiteRtLmLogSeverity` (also fixes the old raw `2` = INFO; now genuinely WARNING)
  3. `set_activation_data_type` → typed `LiteRtLmActivationDataType` (raw values unchanged)
- **Android**: session-level `maxOutputTokens` now applies via `ConversationConfig.maxOutputToken` (new in the 0.15.0 Kotlin SDK — closes the old upstream-tracking TODO; previously iOS-only). Per-message override remains iOS-only (follow-up).
- **Headers**: `cpp/include/` re-vendored at v0.15.0 (`capabilities_c.h` unchanged upstream).
- Framework parity verified: same slices (arm64 device + arm64 sim), MinimumOSVersion 15.0, identical linkage — the new Apple FM adapter is Swift-package-only and does not affect the C framework.

## Inherited engine fixes

Concurrent-engine-init re-entrancy, premature stream-callback invocation, empty-prefill hang, executor/context reset on session release.

## Verification

- [x] `npm run typecheck` + `npm test` — 134 passed, 1 skipped
- [x] Android Robolectric vs 0.15.0 AAR — green (JDK 21 toolchain, as before)
- [x] iOS `xcodebuild test` — 18 passed, 0 failures against the v0.15.0 xcframework
- [ ] On-device streaming smoke test (token flow, tool-call streaming, error path), iOS + Android
- [ ] Benchmark vs 0.14 (tokens/sec, TTFT)