### PR TITLE
feat: resolve variant/backend/channels from litertlm_manifest.json

### DIFF
--- a/src/__tests__/manifestResolver.test.ts
+++ b/src/__tests__/manifestResolver.test.ts
@@ -1,0 +1,217 @@
+import {
+  declaredChannels,
+  fetchManifest,
+  mergeStreamChannels,
+  parseManifest,
+  resolutionFor,
+  resolveFromManifest,
+  resolveVariant,
+  thinkingMarkers,
+  type Manifest,
+} from "../manifestResolver";
+import { DEFAULT_CHANNELS } from "../streamEvents";
+
+/**
+ * Trimmed from the live litert-community/LFM2.5-1.2B-Instruct manifest: a
+ * cpu-only int4 (smaller, android-recommended), a cpu+gpu re-export
+ * (android-gpu-recommended), and a cpu-only int8 (macos-recommended). The
+ * backend-loss shape from #23 lives in the first two: both carry an android
+ * recommendation and the cpu-only file is smaller.
+ */
+const lfmLike = (): Manifest =>
+  parseManifest({
+    manifest_schema: "0.1.0",
+    repo: "litert-community/LFM2.5-1.2B-Instruct",
+    generated: "2026-08-24",
+    model: {
+      display_name: "LFM2.5-1.2B-Instruct",
+      context_length: 4096,
+      capabilities: {
+        thinking: { declared: true, channel: { start: "<think>", end: "</think>" } },
+      },
+      session_defaults: { max_output_tokens_min: 2048, temperature: 0.3, top_k: 40 },
+    },
+    variants: [
+      {
+        file: "LFM2.5-1.2B-Instruct_int4.litertlm",
+        sha256: "a".repeat(64),
+        size_bytes: 736_015_744,
+        quantization: "int4",
+        backends: ["cpu"],
+        default_backend: "cpu",
+        recommended: [
+          { platform: "android", device_class: "midrange", backend: "cpu", reason: "int4 decodes faster" },
+          { platform: "ios", backend: "cpu", reason: "verified path" },
+        ],
+      },
+      {
+        file: "LFM2.5-1.2B-Instruct_int4_gpu.litertlm",
+        sha256: "b".repeat(64),
+        size_bytes: 736_220_768,
+        quantization: "int4 gpu re-export",
+        backends: ["cpu", "gpu"],
+        default_backend: "gpu",
+        recommended: [
+          { platform: "android", device_class: "midrange-2023+", backend: "gpu", reason: "3-6x prefill" },
+          { platform: "macos", backend: "gpu", reason: "~11x prefill" },
+        ],
+        known_issues: ["iPhone Metal fails on this family — use CPU on iOS"],
+      },
+      {
+        file: "LFM2.5-1.2B-Instruct_int8.litertlm",
+        sha256: "c".repeat(64),
+        size_bytes: 1_247_091_440,
+        quantization: "int8",
+        backends: ["cpu"],
+        default_backend: "cpu",
+        recommended: [{ platform: "macos", backend: "cpu", reason: "highest fidelity" }],
+      },
+    ],
+  });
+
+describe("resolveVariant", () => {
+  it("keeps an explicit gpu request across the variant pick (#23 repro)", () => {
+    const r = resolveVariant(lfmLike(), { platform: "android", backend: "gpu" });
+    expect(r?.file).toBe("LFM2.5-1.2B-Instruct_int4_gpu.litertlm");
+    expect(r?.backend).toBe("gpu");
+  });
+
+  it("returns null when no variant lists the requested backend", () => {
+    expect(resolveVariant(lfmLike(), { backend: "npu" })).toBeNull();
+    expect(resolveVariant(lfmLike(), { platform: "android", backend: "npu" })).toBeNull();
+  });
+
+  it("counts only recommendations naming the requested backend", () => {
+    // The gpu re-export carries a macos/gpu recommendation; for a cpu request
+    // the macos/cpu-recommended int8 must win, not the gpu file on cpu.
+    const r = resolveVariant(lfmLike(), { platform: "macos", backend: "cpu" });
+    expect(r?.file).toBe("LFM2.5-1.2B-Instruct_int8.litertlm");
+    expect(r?.backend).toBe("cpu");
+  });
+
+  it("follows platform recommendations when no backend is requested", () => {
+    const r = resolveVariant(lfmLike(), { platform: "android", deviceClass: "midrange-2023+" });
+    expect(r?.file).toBe("LFM2.5-1.2B-Instruct_int4_gpu.litertlm");
+    expect(r?.backend).toBe("gpu");
+  });
+
+  it("notes an unmatched deviceClass in reason instead of silently upgrading", () => {
+    const r = resolveVariant(lfmLike(), { platform: "android", deviceClass: "budget-2019" });
+    expect(r?.reason).toContain("no budget-2019 entry; using the midrange recommendation");
+  });
+
+  it("builds URLs from the fetched revision", () => {
+    const m = lfmLike();
+    m.revision = "abc123";
+    expect(resolveVariant(m)?.url).toContain("/resolve/abc123/");
+    expect(resolveVariant(m, { revision: "deadbeef" })?.url).toContain("/resolve/deadbeef/");
+    expect(resolveVariant(lfmLike())?.url).toContain("/resolve/main/");
+  });
+});
+
+describe("parseManifest", () => {
+  it("rejects non-0.1 schemas and empty backends", () => {
+    expect(() => parseManifest({})).toThrow(/not a litertlm_manifest/);
+    const m = lfmLike() as unknown as { manifest_schema: string };
+    expect(() => parseManifest({ ...lfmLike(), manifest_schema: "0.2.0" })).toThrow(
+      /unsupported manifest_schema/,
+    );
+    expect(m).toBeDefined();
+    expect(() =>
+      parseManifest({
+        manifest_schema: "0.1.0",
+        repo: "t/x",
+        generated: "2026-08-27",
+        model: { display_name: "X" },
+        variants: [{ file: "a.litertlm", quantization: "q", backends: [] }],
+      }),
+    ).toThrow(/no backends/);
+  });
+});
+
+describe("mergeStreamChannels", () => {
+  it("keeps the default toolCall channel when the manifest declares only thinking", () => {
+    const channels = mergeStreamChannels(lfmLike());
+    expect(channels).toContainEqual(
+      DEFAULT_CHANNELS.find((c) => c.type === "toolCall"),
+    );
+    expect(channels).toContainEqual({ type: "thinking", start: "<think>", end: "</think>" });
+  });
+
+  it("lets a 0.1.1 declared tool-call channel override the default markers", () => {
+    const m = lfmLike();
+    m.model.capabilities = {
+      ...m.model.capabilities,
+      channels: [
+        { name: "thought", start: "<think>", end: "</think>", is_reasoning: true },
+        { name: "tool_call", start: "<function>", end: "</function>" },
+      ],
+    };
+    const channels = mergeStreamChannels(m);
+    expect(channels).toContainEqual({ type: "toolCall", start: "<function>", end: "</function>" });
+    expect(channels).toContainEqual({ type: "thinking", start: "<think>", end: "</think>" });
+    expect(declaredChannels(m)).toHaveLength(2);
+  });
+
+  it("returns the defaults untouched for a manifest declaring nothing", () => {
+    const m = lfmLike();
+    m.model.capabilities = {};
+    expect(mergeStreamChannels(m)).toEqual(DEFAULT_CHANNELS);
+    expect(thinkingMarkers(m)).toBeUndefined();
+  });
+});
+
+describe("resolutionFor", () => {
+  it("maps session_defaults into an LLMConfig fragment", () => {
+    const r = resolutionFor(lfmLike(), { platform: "android", backend: "gpu" });
+    expect(r).not.toBeNull();
+    expect(r?.backend).toBe("gpu");
+    expect(r?.config).toEqual({
+      backend: "gpu",
+      maxOutputTokens: 2048,
+      temperature: 0.3,
+      topK: 40,
+    });
+    expect(r?.streamChannels.map((c) => c.type).sort()).toEqual(["thinking", "toolCall"]);
+    expect(r?.sha256).toBe("b".repeat(64));
+    expect(r?.notes).toContain("iPhone Metal fails on this family — use CPU on iOS");
+    expect(r?.contextLength).toBe(4096);
+  });
+
+  it("propagates null for an unsupported explicit backend", () => {
+    expect(resolutionFor(lfmLike(), { backend: "npu" })).toBeNull();
+  });
+});
+
+describe("resolveFromManifest / fetchManifest", () => {
+  const manifestBody = JSON.stringify(lfmLike());
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({ ok: true, text: () => Promise.resolve(manifestBody) } as Response);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("fetches, resolves, and pins URLs to the fetched revision", async () => {
+    const r = await resolveFromManifest("litert-community/LFM2.5-1.2B-Instruct", {
+      platform: "android",
+      backend: "gpu",
+      revision: "abc123",
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://huggingface.co/litert-community/LFM2.5-1.2B-Instruct/resolve/abc123/litertlm_manifest.json",
+    );
+    expect(r?.file).toBe("LFM2.5-1.2B-Instruct_int4_gpu.litertlm");
+    expect(r?.url).toContain("/resolve/abc123/");
+  });
+
+  it("throws with the URL and status when the manifest is missing", async () => {
+    fetchSpy.mockResolvedValue({ ok: false, status: 404 } as Response);
+    await expect(fetchManifest("litert-community/NoManifest")).rejects.toThrow(/HTTP 404/);
+  });
+});

--- a/src/__tests__/manifestResolver.test.ts
+++ b/src/__tests__/manifestResolver.test.ts
@@ -1,6 +1,8 @@
 import {
   declaredChannels,
   fetchManifest,
+  manifestFetchStatus,
+  manifestPlatformFor,
   mergeStreamChannels,
   parseManifest,
   resolutionFor,
@@ -9,7 +11,7 @@ import {
   thinkingMarkers,
   type Manifest,
 } from "../manifestResolver";
-import { DEFAULT_CHANNELS } from "../streamEvents";
+import { createStreamEventParser, DEFAULT_CHANNELS } from "../streamEvents";
 
 /**
  * Trimmed from the live litert-community/LFM2.5-1.2B-Instruct manifest: a
@@ -29,7 +31,12 @@ const lfmLike = (): Manifest =>
       capabilities: {
         thinking: { declared: true, channel: { start: "<think>", end: "</think>" } },
       },
-      session_defaults: { max_output_tokens_min: 2048, temperature: 0.3, top_k: 40 },
+      session_defaults: {
+        max_output_tokens_min: 2048,
+        temperature: 0.3,
+        top_k: 40,
+        notes: "Reasoning model: keep maxOutputTokens ≥ 2048 so it can finish thinking.",
+      },
     },
     variants: [
       {
@@ -112,11 +119,9 @@ describe("resolveVariant", () => {
 describe("parseManifest", () => {
   it("rejects non-0.1 schemas and empty backends", () => {
     expect(() => parseManifest({})).toThrow(/not a litertlm_manifest/);
-    const m = lfmLike() as unknown as { manifest_schema: string };
     expect(() => parseManifest({ ...lfmLike(), manifest_schema: "0.2.0" })).toThrow(
       /unsupported manifest_schema/,
     );
-    expect(m).toBeDefined();
     expect(() =>
       parseManifest({
         manifest_schema: "0.1.0",
@@ -159,6 +164,54 @@ describe("mergeStreamChannels", () => {
     expect(mergeStreamChannels(m)).toEqual(DEFAULT_CHANNELS);
     expect(thinkingMarkers(m)).toBeUndefined();
   });
+
+  // From the #25 review: the whitespace-carrying markers must meet the real
+  // parser, which is where the original bug lived.
+  it("parses a manifest's whitespace-carrying markers end to end", () => {
+    const qwenLike = parseManifest({
+      manifest_schema: "0.1.0",
+      repo: "litert-community/Qwen3-4B-Thinking-2507",
+      generated: "2026-08-24",
+      model: {
+        display_name: "Qwen3-4B-Thinking",
+        capabilities: {
+          thinking: { declared: true, channel: { start: "<think>\n", end: "\n</think>" } },
+        },
+      },
+      variants: [{ file: "model.litertlm", quantization: "int4", backends: ["cpu"] }],
+    });
+    const parser = createStreamEventParser(resolutionFor(qwenLike, {})!.streamChannels);
+    const events = [
+      ...parser.push("<think>\nlet me reason"),
+      ...parser.push(" about this\n</think>The answer is 4."),
+      ...parser.finish(),
+    ];
+    expect(events.filter((e) => e.type === "thinking").map((e) => e.text).join(""))
+      .toBe("let me reason about this");
+    expect(events.filter((e) => e.type === "token").map((e) => e.text).join(""))
+      .toBe("The answer is 4.");
+  });
+});
+
+describe("manifestPlatformFor", () => {
+  it("forwards every OS a manifest can name and drops the rest", () => {
+    // react-native-macos / -windows must keep their recommendations (#25 review).
+    for (const os of ["android", "ios", "macos", "windows"]) {
+      expect(manifestPlatformFor(os)).toBe(os);
+    }
+    expect(manifestPlatformFor("web")).toBeUndefined();
+    expect(manifestPlatformFor("native")).toBeUndefined();
+  });
+
+  it("changes which variant wins for a macos caller", () => {
+    // No platform → smallest file; macos → the gpu re-export it recommends.
+    expect(resolutionFor(lfmLike(), { platform: manifestPlatformFor("web") })?.file).toBe(
+      "LFM2.5-1.2B-Instruct_int4.litertlm",
+    );
+    const mac = resolutionFor(lfmLike(), { platform: manifestPlatformFor("macos") });
+    expect(mac?.file).toBe("LFM2.5-1.2B-Instruct_int4_gpu.litertlm");
+    expect(mac?.reason).toContain("recommended for macos");
+  });
 });
 
 describe("resolutionFor", () => {
@@ -178,6 +231,26 @@ describe("resolutionFor", () => {
     expect(r?.contextLength).toBe(4096);
   });
 
+  it("surfaces session_defaults.notes after the variant's notes, and the raw object", () => {
+    const m = lfmLike();
+    const r = resolutionFor(m, { platform: "android", backend: "gpu" });
+    expect(r?.notes).toEqual([
+      "iPhone Metal fails on this family — use CPU on iOS",
+      "Reasoning model: keep maxOutputTokens ≥ 2048 so it can finish thinking.",
+    ]);
+    // The raw object rides along so a key a later 0.1.x adds needs no re-fetch.
+    expect(r?.sessionDefaults).toBe(m.model.session_defaults);
+
+    m.model.session_defaults = { notes: "" };
+    expect(resolutionFor(m, { platform: "android", backend: "gpu" })?.notes).toEqual([
+      "iPhone Metal fails on this family — use CPU on iOS",
+    ]);
+    delete m.model.session_defaults;
+    const bare = resolutionFor(m, { platform: "android", backend: "gpu" });
+    expect(bare?.sessionDefaults).toBeUndefined();
+    expect(bare?.notes).toEqual(["iPhone Metal fails on this family — use CPU on iOS"]);
+  });
+
   it("propagates null for an unsupported explicit backend", () => {
     expect(resolutionFor(lfmLike(), { backend: "npu" })).toBeNull();
   });
@@ -185,16 +258,19 @@ describe("resolutionFor", () => {
 
 describe("resolveFromManifest / fetchManifest", () => {
   const manifestBody = JSON.stringify(lfmLike());
+  const okResponse = (body: string) =>
+    ({ ok: true, text: () => Promise.resolve(body) }) as Response;
   let fetchSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    fetchSpy = jest
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue({ ok: true, text: () => Promise.resolve(manifestBody) } as Response);
+    fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(okResponse(manifestBody));
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
     fetchSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
   it("fetches, resolves, and pins URLs to the fetched revision", async () => {
@@ -205,13 +281,87 @@ describe("resolveFromManifest / fetchManifest", () => {
     });
     expect(fetchSpy).toHaveBeenCalledWith(
       "https://huggingface.co/litert-community/LFM2.5-1.2B-Instruct/resolve/abc123/litertlm_manifest.json",
+      { signal: undefined },
     );
     expect(r?.file).toBe("LFM2.5-1.2B-Instruct_int4_gpu.litertlm");
     expect(r?.url).toContain("/resolve/abc123/");
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it("throws with the URL and status when the manifest is missing", async () => {
+  it("fetchManifest itself still throws, carrying the URL and status", async () => {
     fetchSpy.mockResolvedValue({ ok: false, status: 404 } as Response);
-    await expect(fetchManifest("litert-community/NoManifest")).rejects.toThrow(/HTTP 404/);
+    const missing = fetchManifest("litert-community/NoManifest");
+    await expect(missing).rejects.toThrow(/no litertlm_manifest\.json at .*NoManifest.*HTTP 404/);
+    expect(manifestFetchStatus(await missing.catch((e) => e))).toBe(404);
+
+    // A gated repo is not a missing manifest — say what happened.
+    fetchSpy.mockResolvedValue({ ok: false, status: 403 } as Response);
+    const gated = fetchManifest("t/x");
+    await expect(gated).rejects.toThrow(/^HTTP 403 fetching /);
+    expect(manifestFetchStatus(await gated.catch((e) => e))).toBe(403);
+    expect(manifestFetchStatus(new Error("plain"))).toBeUndefined();
+    expect(manifestFetchStatus("boom")).toBeUndefined();
+  });
+
+  // The null cases agreed in #23/#25 — missing manifest, unknown schema,
+  // network failure, unresolvable variant. Most Hub repos ship no manifest
+  // yet, so the common path must not need a try/catch at the call site —
+  // and must not put a LogBox warning on every dev launch either.
+  it("returns null, silently, when the repo has no manifest", async () => {
+    fetchSpy.mockResolvedValue({ ok: false, status: 404 } as Response);
+    await expect(resolveFromManifest("litert-community/NoManifest")).resolves.toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null, with one warning, for any other HTTP status", async () => {
+    fetchSpy.mockResolvedValue({ ok: false, status: 403 } as Response);
+    await expect(resolveFromManifest("t/x")).resolves.toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/resolveFromManifest\(t\/x\): HTTP 403 fetching /);
+  });
+
+  it("returns null when the manifest's schema is newer than this reader", async () => {
+    fetchSpy.mockResolvedValue(
+      okResponse(JSON.stringify({ ...lfmLike(), manifest_schema: "0.2.0" })),
+    );
+    await expect(resolveFromManifest("t/x")).resolves.toBeNull();
+    expect(warnSpy.mock.calls[0][0]).toMatch(/unsupported manifest_schema 0\.2\.0/);
+  });
+
+  it("returns null when the fetch fails or the body is not a manifest", async () => {
+    fetchSpy.mockRejectedValue(new TypeError("Network request failed"));
+    await expect(resolveFromManifest("t/x")).resolves.toBeNull();
+    expect(warnSpy.mock.calls[0][0]).toMatch(/Network request failed/);
+
+    fetchSpy.mockResolvedValue(okResponse("<html>not json</html>"));
+    await expect(resolveFromManifest("t/x")).resolves.toBeNull();
+
+    fetchSpy.mockRejectedValue("boom");
+    await expect(resolveFromManifest("t/x")).resolves.toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(3);
+    expect(warnSpy.mock.calls[2][0]).toMatch(/boom/);
+  });
+
+  it("forwards an AbortSignal and treats an aborted fetch as null, silently", async () => {
+    const controller = new AbortController();
+    await resolveFromManifest("t/x", { signal: controller.signal });
+    expect(fetchSpy).toHaveBeenLastCalledWith(expect.any(String), { signal: controller.signal });
+
+    // The caller asked for the abort (a startup timeout, an unmount) — no warning.
+    fetchSpy.mockRejectedValue(Object.assign(new Error("Aborted"), { name: "AbortError" }));
+    controller.abort();
+    await expect(resolveFromManifest("t/x", { signal: controller.signal })).resolves.toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    // A rejection while the signal is still live is a real failure, and warns.
+    await expect(
+      resolveFromManifest("t/x", { signal: new AbortController().signal }),
+    ).resolves.toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("still returns null, silently, for an unsupported explicit backend", async () => {
+    await expect(resolveFromManifest("t/x", { backend: "npu" })).resolves.toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import { Platform } from "react-native";
 import type { Backend } from "./specs/LiteRTLM.nitro";
+import {
+  resolveFromManifest as resolveFromManifestCore,
+  type ManifestResolution,
+  type ResolveFromManifestOptions,
+} from "./manifestResolver";
 
 export type {
   LiteRTLM,
@@ -56,6 +61,57 @@ export type {
   StreamChannel,
   StreamEventParser,
 } from "./streamEvents";
+
+// Manifest-driven variant/backend/channel selection from a model repo's
+// litertlm_manifest.json (issue #23). Core is react-native-free; this wrapper
+// defaults `platform` to the device OS.
+export {
+  resolutionFor,
+  resolveVariant,
+  mergeStreamChannels,
+  parseManifest,
+  fetchManifest,
+  thinkingMarkers,
+  declaredChannels,
+} from "./manifestResolver";
+export type {
+  Manifest,
+  ManifestVariant,
+  ManifestCapabilities,
+  ManifestRecommendation,
+  ManifestPlatform,
+  ManifestResolution,
+  ResolveFromManifestOptions,
+  ResolveVariantOptions,
+  VariantResolution,
+  DeclaredChannel,
+  ThinkingChannel,
+} from "./manifestResolver";
+
+/**
+ * Fetch `<repo>`'s litertlm_manifest.json from the Hugging Face Hub and pick
+ * the right .litertlm variant, backend, config, and stream channels for this
+ * device. `platform` defaults to this device's OS; returns null when an
+ * explicitly requested backend is listed by no variant (fall back to your
+ * current loading path).
+ *
+ * @example
+ * ```typescript
+ * const resolution = await resolveFromManifest("litert-community/LFM2.5-1.2B-Instruct");
+ * if (resolution) {
+ *   const llm = createLLM({ streamChannels: resolution.streamChannels });
+ *   await llm.loadModel(resolution.url, { ...resolution.config });
+ * }
+ * ```
+ */
+export function resolveFromManifest(
+  repo: string,
+  options: ResolveFromManifestOptions = {},
+): Promise<ManifestResolution | null> {
+  const platform =
+    Platform.OS === "android" || Platform.OS === "ios" ? Platform.OS : undefined;
+  return resolveFromManifestCore(repo, { platform, ...options });
+}
 
 export type {
   LiteRTLMInstance,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Platform } from "react-native";
 import type { Backend } from "./specs/LiteRTLM.nitro";
 import {
+  manifestPlatformFor,
   resolveFromManifest as resolveFromManifestCore,
   type ManifestResolution,
   type ResolveFromManifestOptions,
@@ -71,11 +72,13 @@ export {
   mergeStreamChannels,
   parseManifest,
   fetchManifest,
+  manifestFetchStatus,
   thinkingMarkers,
   declaredChannels,
 } from "./manifestResolver";
 export type {
   Manifest,
+  ManifestFetchError,
   ManifestVariant,
   ManifestCapabilities,
   ManifestRecommendation,
@@ -91,9 +94,12 @@ export type {
 /**
  * Fetch `<repo>`'s litertlm_manifest.json from the Hugging Face Hub and pick
  * the right .litertlm variant, backend, config, and stream channels for this
- * device. `platform` defaults to this device's OS; returns null when an
- * explicitly requested backend is listed by no variant (fall back to your
- * current loading path).
+ * device. `platform` defaults to this device's OS; pass it to override.
+ * Never throws: returns null when the repo ships no manifest, the manifest's
+ * schema is unsupported, the fetch fails or is aborted (`options.signal`),
+ * or no variant lists an explicitly requested backend — fall back to your
+ * current loading path. Only the unexpected cases log a console.warn line;
+ * a missing manifest and an abort are silent.
  *
  * @example
  * ```typescript
@@ -108,9 +114,10 @@ export function resolveFromManifest(
   repo: string,
   options: ResolveFromManifestOptions = {},
 ): Promise<ManifestResolution | null> {
-  const platform =
-    Platform.OS === "android" || Platform.OS === "ios" ? Platform.OS : undefined;
-  return resolveFromManifestCore(repo, { platform, ...options });
+  return resolveFromManifestCore(repo, {
+    ...options,
+    platform: options.platform ?? manifestPlatformFor(Platform.OS),
+  });
 }
 
 export type {

--- a/src/manifestResolver.ts
+++ b/src/manifestResolver.ts
@@ -11,7 +11,9 @@
  * Spec: https://github.com/john-rocky/hf-to-litertlm/blob/main/manifest/SCHEMA.md
  * The core reader (parse/resolve) is vendored from the reference TypeScript
  * reader (john-rocky/hf-to-litertlm `readers/ts`, v0.2.0) with `resolve`
- * renamed to `resolveVariant`; it is IO-free and dependency-free. The
+ * renamed to `resolveVariant`, plus an optional `signal` and a
+ * status-carrying error on `fetchManifest`; it is dependency-free and,
+ * apart from `fetchManifest`, IO-free. The
  * react-native layer (`resolveFromManifest`, `mergeStreamChannels`) is at the
  * bottom. This module deliberately does not import react-native — `index.ts`
  * injects `Platform.OS` as the default platform.
@@ -151,12 +153,41 @@ export function parseManifest(input: string | object): Manifest {
   return m;
 }
 
-/** Fetch <repo>'s manifest from the Hugging Face Hub. resolveVariant() URLs follow the revision fetched here. */
-export async function fetchManifest(repo: string, revision = "main"): Promise<Manifest> {
+/**
+ * Thrown by {@link fetchManifest} for a non-2xx response. `status` tells a
+ * missing manifest (404) from a gated repo (401/403) or a Hub outage (5xx).
+ */
+export interface ManifestFetchError extends Error {
+  status: number;
+}
+
+/** The HTTP status carried by a {@link ManifestFetchError}, or undefined for any other error. */
+export function manifestFetchStatus(e: unknown): number | undefined {
+  const status = e instanceof Error ? (e as Partial<ManifestFetchError>).status : undefined;
+  return typeof status === "number" ? status : undefined;
+}
+
+/**
+ * Fetch <repo>'s manifest from the Hugging Face Hub. resolveVariant() URLs
+ * follow the revision fetched here. Throws on a non-2xx response (a
+ * {@link ManifestFetchError} carrying the status), an unsupported schema, or
+ * a failed/aborted fetch — {@link resolveFromManifest} turns all of those
+ * into null; call this directly when you want the error. `signal` aborts
+ * the fetch.
+ */
+export async function fetchManifest(
+  repo: string,
+  revision = "main",
+  signal?: AbortSignal,
+): Promise<Manifest> {
   const url = `https://huggingface.co/${repo}/resolve/${encodeURIComponent(revision)}/litertlm_manifest.json`;
-  const res = await fetch(url);
+  const res = await fetch(url, { signal });
   if (!res.ok) {
-    throw new Error(`no litertlm_manifest.json at ${url} (HTTP ${res.status})`);
+    const message =
+      res.status === 404
+        ? `no litertlm_manifest.json at ${url} (HTTP 404)`
+        : `HTTP ${res.status} fetching ${url}`;
+    throw Object.assign(new Error(message), { status: res.status }) as ManifestFetchError;
   }
   const m = parseManifest(await res.text());
   m.revision = revision;
@@ -325,10 +356,34 @@ export function mergeStreamChannels(
   return [...merged.values()];
 }
 
+/** react-native `Platform.OS` values that are also manifest `recommended[].platform` keys. */
+const MANIFEST_PLATFORMS = new Set<string>([
+  "android",
+  "ios",
+  "macos",
+  "windows",
+] satisfies ManifestPlatform[]);
+
+/**
+ * The manifest platform for a react-native `Platform.OS` value, or undefined
+ * for one no manifest names (`web`, `native`). index.ts injects this as the
+ * default `platform`, so react-native-macos and -windows keep their
+ * recommendations instead of silently falling back to the smallest file.
+ */
+export function manifestPlatformFor(os: string): ManifestPlatform | undefined {
+  return MANIFEST_PLATFORMS.has(os) ? (os as ManifestPlatform) : undefined;
+}
+
 /** Options for {@link resolveFromManifest}. */
 export interface ResolveFromManifestOptions extends ResolveVariantOptions {
   /** Hub revision to fetch and pin (default "main"); download URLs follow it. */
   revision?: string;
+  /**
+   * Aborts the manifest fetch — pass an AbortController's signal so a
+   * startup-time resolve can't hang on a bad connection. An aborted fetch
+   * resolves to null, silently.
+   */
+  signal?: AbortSignal;
 }
 
 /** Everything an app needs to load the chosen variant. */
@@ -354,7 +409,18 @@ export interface ManifestResolution {
   sha256?: string;
   sizeBytes?: number;
   contextLength?: number;
-  /** platform_notes + known_issues of the chosen variant — worth surfacing. */
+  /**
+   * The manifest's raw `session_defaults` — an open object (SCHEMA.md
+   * declares `max_output_tokens_min`, `temperature`, `top_k`, `top_p`,
+   * `notes`). `config` maps the keys it knows; any key a later 0.1.x adds is
+   * reachable here without a re-fetch.
+   */
+  sessionDefaults?: Record<string, unknown>;
+  /**
+   * Worth surfacing to the developer: the chosen variant's platform_notes
+   * and known_issues, then the model's `session_defaults.notes` (curated
+   * guidance) when the manifest carries one.
+   */
   notes: string[];
   /** Why this variant/backend was chosen (for logs). */
   reason: string;
@@ -397,9 +463,19 @@ export function resolutionFor(
   if (typeof sd.top_p === "number") {
     config.topP = sd.top_p;
   }
-  // TODO(#23): decide whether context_length should seed maxContextTokens
-  // (model max vs engine budget are different knobs) and whether
-  // streamToolCalls should default on when the manifest declares channels.
+  // Two knobs deliberately NOT derived from the manifest (agreed in the #25
+  // review; not final):
+  // - `context_length` does not seed `maxContextTokens`. They look like the
+  //   same number but are different knobs: the manifest value is what the
+  //   model can address, the package default is a memory ceiling, and quietly
+  //   raising it to 128K on a phone is the OOM the pre-flight check exists to
+  //   catch. `contextLength` is on the resolution for apps that want more,
+  //   knowingly.
+  // - `streamToolCalls` stays off even when the manifest declares a tool
+  //   channel. A declared channel says the model *can* emit tool calls, not
+  //   that this app wants to handle them, and switching engine behaviour on
+  //   as a side effect of "resolve a URL" would surprise a caller. Revisit
+  //   once the bundle-header read lands and the signal is local, not fetched.
 
   return {
     url: r.url,
@@ -410,7 +486,8 @@ export function resolutionFor(
     sha256: r.variant.sha256,
     sizeBytes: r.variant.size_bytes,
     contextLength: r.contextLength,
-    notes: r.notes,
+    sessionDefaults: r.sessionDefaults,
+    notes: typeof sd.notes === "string" && sd.notes !== "" ? [...r.notes, sd.notes] : r.notes,
     reason: r.reason,
   };
 }
@@ -428,13 +505,33 @@ export function resolutionFor(
  * ```
  *
  * `platform` defaults to this device's OS when called through the package
- * export (index.ts injects `Platform.OS`). Returns null when an explicitly
- * requested backend is listed by no variant.
+ * export (index.ts injects `Platform.OS`).
+ *
+ * Never throws. Returns null whenever the manifest can't help — the repo
+ * ships none (HTTP 404, the common case on the Hub today), its schema is
+ * newer than this reader supports, the fetch fails or is aborted, or no
+ * variant lists an explicitly requested backend — so callers fall back to
+ * their current (non-manifest) loading path without a try/catch.
+ *
+ * The expected outcomes are silent: no manifest, an abort the caller asked
+ * for, an unlisted backend. Anything else (unsupported schema, a body that
+ * is not a manifest, a network failure, a non-404 HTTP status) is reported
+ * with one console.warn line naming the reason — on React Native, LogBox
+ * shows console.warn in dev, which is too loud for the common path.
  */
 export async function resolveFromManifest(
   repo: string,
   opts: ResolveFromManifestOptions = {},
 ): Promise<ManifestResolution | null> {
-  const manifest = await fetchManifest(repo, opts.revision ?? "main");
-  return resolutionFor(manifest, opts);
+  try {
+    const manifest = await fetchManifest(repo, opts.revision ?? "main", opts.signal);
+    return resolutionFor(manifest, opts);
+  } catch (e) {
+    if (opts.signal?.aborted || manifestFetchStatus(e) === 404) {
+      return null;
+    }
+    const reason = e instanceof Error ? e.message : String(e);
+    console.warn(`resolveFromManifest(${repo}): ${reason} — returning null`);
+    return null;
+  }
 }

--- a/src/manifestResolver.ts
+++ b/src/manifestResolver.ts
@@ -1,0 +1,440 @@
+/**
+ * litertlm_manifest.json resolver — pick the right .litertlm file, backend,
+ * and stream channels for a device from a model repo's deployment manifest.
+ *
+ * Repos converted for LiteRT-LM ship a `litertlm_manifest.json` at their root
+ * describing every variant (backends verified to generate, per-platform
+ * recommendations with evidence, sha256/size, thinking markers, session
+ * defaults). This module reads it so apps stop hardcoding file names and
+ * channel markers per model.
+ *
+ * Spec: https://github.com/john-rocky/hf-to-litertlm/blob/main/manifest/SCHEMA.md
+ * The core reader (parse/resolve) is vendored from the reference TypeScript
+ * reader (john-rocky/hf-to-litertlm `readers/ts`, v0.2.0) with `resolve`
+ * renamed to `resolveVariant`; it is IO-free and dependency-free. The
+ * react-native layer (`resolveFromManifest`, `mergeStreamChannels`) is at the
+ * bottom. This module deliberately does not import react-native — `index.ts`
+ * injects `Platform.OS` as the default platform.
+ *
+ * https://github.com/hung-yueh/react-native-litert-lm/issues/23
+ */
+
+import type { Backend, LLMConfig } from "./specs/LiteRTLM.nitro";
+import { DEFAULT_CHANNELS, type StreamChannel } from "./streamEvents";
+
+// ─── Vendored reference reader (types) ──────────────────────────────────────
+
+/** Platform key used by manifest `recommended` rows (superset of RN's OS). */
+export type ManifestPlatform = "android" | "ios" | "macos" | "windows" | "linux";
+
+export interface ThinkingChannel {
+  start: string;
+  end: string;
+}
+
+/** One entry of the bundle's declared channel set (manifest 0.1.1+). */
+export interface DeclaredChannel {
+  name: string;
+  start: string;
+  end: string;
+  is_reasoning?: boolean;
+}
+
+export interface ManifestCapabilities {
+  vision?: boolean;
+  audio?: boolean;
+  thinking?: { declared: boolean; channel?: ThinkingChannel };
+  /** Full bundle-declared channel set (0.1.1+); `thinking` mirrors the first entry. */
+  channels?: DeclaredChannel[];
+}
+
+export interface ManifestRecommendation {
+  platform: ManifestPlatform;
+  device_class?: string;
+  backend: Backend;
+  reason?: string;
+}
+
+export interface ManifestVariant {
+  file: string;
+  sha256?: string;
+  size_bytes?: number;
+  quantization: string;
+  /** Backends this file is verified to GENERATE on — not merely load. */
+  backends: Backend[];
+  default_backend?: Backend;
+  min_runtime_version?: string;
+  recommended?: ManifestRecommendation[];
+  requirements?: { peak_ram_mb?: number; platform_notes?: string[] };
+  known_issues?: string[];
+  sections?: {
+    type: string;
+    size_bytes?: number;
+    model_type?: string;
+    backend_constraint?: string;
+  }[];
+}
+
+export interface Manifest {
+  manifest_schema: string;
+  repo: string;
+  generated: string;
+  /**
+   * Not part of the file: the revision the manifest was fetched at, stamped by
+   * fetchManifest() so resolveVariant() URLs follow a pinned fetch.
+   */
+  revision?: string;
+  model: {
+    display_name: string;
+    base_model?: string;
+    architecture?: string;
+    parameters_b?: number;
+    license?: string;
+    context_length?: number;
+    capabilities?: ManifestCapabilities;
+    session_defaults?: Record<string, unknown>;
+  };
+  variants: ManifestVariant[];
+}
+
+export interface ResolveVariantOptions {
+  platform?: ManifestPlatform;
+  /**
+   * Explicit backend request. A filter, not a preference: only variants
+   * listing it are considered, and resolveVariant() returns null when none
+   * does — it never substitutes a backend the caller didn't ask for.
+   */
+  backend?: Backend;
+  deviceClass?: string;
+  /** Repo revision for the download URL; overrides the manifest's fetched revision (default "main"). */
+  revision?: string;
+}
+
+export interface VariantResolution {
+  /** File name inside the repo. */
+  file: string;
+  /** Direct download URL (huggingface.co/<repo>/resolve/<revision>/<file>). */
+  url: string;
+  backend: Backend;
+  variant: ManifestVariant;
+  sessionDefaults?: Record<string, unknown>;
+  capabilities?: ManifestCapabilities;
+  thinkingChannel?: ThinkingChannel;
+  contextLength?: number;
+  /** platform_notes + known_issues of the chosen variant — surface these to the developer. */
+  notes: string[];
+  /** Why this variant/backend was chosen (for logs). */
+  reason: string;
+}
+
+// ─── Vendored reference reader (implementation) ─────────────────────────────
+
+export function parseManifest(input: string | object): Manifest {
+  const m = (typeof input === "string" ? JSON.parse(input) : input) as Manifest;
+  if (
+    !m ||
+    typeof m !== "object" ||
+    !m.manifest_schema ||
+    !Array.isArray(m.variants) ||
+    m.variants.length === 0
+  ) {
+    throw new Error("not a litertlm_manifest.json (missing manifest_schema or variants)");
+  }
+  if (!/^0\.1\./.test(m.manifest_schema)) {
+    throw new Error(`unsupported manifest_schema ${m.manifest_schema} (reader supports 0.1.x)`);
+  }
+  for (const v of m.variants) {
+    if (!Array.isArray(v.backends) || v.backends.length === 0) {
+      throw new Error(`variant ${v?.file ?? "?"} lists no backends (schema requires minItems: 1)`);
+    }
+  }
+  return m;
+}
+
+/** Fetch <repo>'s manifest from the Hugging Face Hub. resolveVariant() URLs follow the revision fetched here. */
+export async function fetchManifest(repo: string, revision = "main"): Promise<Manifest> {
+  const url = `https://huggingface.co/${repo}/resolve/${encodeURIComponent(revision)}/litertlm_manifest.json`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`no litertlm_manifest.json at ${url} (HTTP ${res.status})`);
+  }
+  const m = parseManifest(await res.text());
+  m.revision = revision;
+  return m;
+}
+
+interface ScoredVariant {
+  variant: ManifestVariant;
+  backend: Backend;
+  score: number;
+  reason: string;
+}
+
+/**
+ * Pick the variant + backend for a device. Manifest v0.1 algorithm,
+ * deterministic — identical to the reference readers:
+ *
+ * 1. An explicit `backend` request is a filter, not a score: only variants
+ *    listing it compete, the result keeps that backend, and resolveVariant()
+ *    returns null when no variant lists it — it never substitutes another
+ *    backend.
+ * 2. A variant with a `recommended` entry matching the requested platform
+ *    wins; matching device_class too ranks higher. When a backend was
+ *    requested, only recommendations naming that backend count.
+ * 3. Otherwise the smallest variant (by size_bytes), on the requested backend
+ *    (else its default_backend, else the first listed backend).
+ *
+ * Ties break toward the smaller file. The resolver never returns a backend
+ * absent from the variant's verified `backends` list.
+ */
+export function resolveVariant(
+  manifest: Manifest,
+  opts: ResolveVariantOptions = {},
+): VariantResolution | null {
+  const requested = opts.backend;
+  const candidates = requested
+    ? manifest.variants.filter((v) => v.backends.includes(requested))
+    : manifest.variants;
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const scored: ScoredVariant[] = candidates.map((v) => {
+    let score = 0;
+    let backend: Backend | undefined = requested;
+    let reason = requested
+      ? `supports requested backend ${requested}`
+      : "fallback: smallest variant";
+    if (opts.platform && v.recommended) {
+      const recs = v.recommended.filter(
+        (r) =>
+          r.platform === opts.platform &&
+          v.backends.includes(r.backend) &&
+          (!requested || r.backend === requested),
+      );
+      const classRec = opts.deviceClass
+        ? recs.find((r) => r.device_class === opts.deviceClass)
+        : undefined;
+      const rec = classRec ?? recs.find((r) => !r.device_class || !opts.deviceClass) ?? recs[0];
+      if (rec) {
+        score = classRec ? 300 : 200;
+        backend = requested ?? rec.backend;
+        const classNote =
+          !classRec && opts.deviceClass && rec.device_class
+            ? ` (no ${opts.deviceClass} entry; using the ${rec.device_class} recommendation)`
+            : "";
+        reason =
+          `recommended for ${opts.platform}${classRec ? `/${opts.deviceClass}` : ""}` +
+          `${classNote}: ${rec.reason ?? ""}`.trimEnd();
+      }
+    }
+    if (!backend) {
+      backend =
+        v.default_backend && v.backends.includes(v.default_backend)
+          ? v.default_backend
+          : (v.backends[0] ?? "cpu");
+    }
+    return { variant: v, backend, score, reason };
+  });
+
+  scored.sort(
+    (a, b) =>
+      b.score - a.score || (a.variant.size_bytes ?? Infinity) - (b.variant.size_bytes ?? Infinity),
+  );
+  const best = scored[0];
+  const v = best.variant;
+  const caps = manifest.model.capabilities;
+  const revision = encodeURIComponent(opts.revision ?? manifest.revision ?? "main");
+  return {
+    file: v.file,
+    // Encode per path segment so a repo that nests variants in subfolders
+    // (file containing '/') keeps its structure — '%2F' would 404.
+    url: `https://huggingface.co/${manifest.repo}/resolve/${revision}/${v.file
+      .split("/")
+      .map(encodeURIComponent)
+      .join("/")}`,
+    backend: best.backend,
+    variant: v,
+    sessionDefaults: manifest.model.session_defaults,
+    capabilities: caps,
+    thinkingChannel: caps?.thinking?.declared ? caps.thinking.channel : undefined,
+    contextLength: manifest.model.context_length,
+    notes: [...(v.requirements?.platform_notes ?? []), ...(v.known_issues ?? [])],
+    reason: best.reason,
+  };
+}
+
+/** The model's declared thinking markers (exact strings, whitespace included). */
+export function thinkingMarkers(manifest: Manifest): ThinkingChannel | undefined {
+  const t = manifest.model.capabilities?.thinking;
+  return t?.declared ? t.channel : undefined;
+}
+
+/** The bundle's full declared channel set (manifest 0.1.1+); empty for 0.1.0 manifests. */
+export function declaredChannels(manifest: Manifest): DeclaredChannel[] {
+  return manifest.model.capabilities?.channels ?? [];
+}
+
+// ─── react-native layer ─────────────────────────────────────────────────────
+
+/**
+ * Map a manifest-declared channel to a StreamEventType, or null when this
+ * package has no event type for it yet.
+ */
+function streamTypeFor(c: DeclaredChannel): StreamChannel["type"] | null {
+  if (c.is_reasoning || c.name === "thought" || c.name === "thinking") {
+    return "thinking";
+  }
+  if (c.name.includes("tool")) {
+    return "toolCall";
+  }
+  return null;
+}
+
+/**
+ * Merge the manifest's declared channels OVER the package defaults, by type.
+ *
+ * `createLLM({ streamChannels })` replaces the whole array, so handing it only
+ * the manifest's thinking markers would silently drop tool-call parsing
+ * (#23). This merge keeps every default channel the manifest doesn't
+ * redeclare — the default toolCall entry survives a manifest that declares
+ * only thinking.
+ */
+export function mergeStreamChannels(
+  manifest: Manifest,
+  defaults: StreamChannel[] = DEFAULT_CHANNELS,
+): StreamChannel[] {
+  const merged = new Map<StreamChannel["type"], StreamChannel>();
+  for (const c of defaults) {
+    merged.set(c.type, c);
+  }
+  const declared = declaredChannels(manifest);
+  for (const c of declared) {
+    const type = streamTypeFor(c);
+    if (type) {
+      merged.set(type, { type, start: c.start, end: c.end });
+    }
+  }
+  if (declared.length === 0) {
+    // 0.1.0 manifests declare thinking markers only.
+    const t = thinkingMarkers(manifest);
+    if (t) {
+      merged.set("thinking", { type: "thinking", start: t.start, end: t.end });
+    }
+  }
+  return [...merged.values()];
+}
+
+/** Options for {@link resolveFromManifest}. */
+export interface ResolveFromManifestOptions extends ResolveVariantOptions {
+  /** Hub revision to fetch and pin (default "main"); download URLs follow it. */
+  revision?: string;
+}
+
+/** Everything an app needs to load the chosen variant. */
+export interface ManifestResolution {
+  /** Direct download URL of the chosen .litertlm — feed to `loadModel` / ModelRegistry. */
+  url: string;
+  file: string;
+  backend: Backend;
+  /**
+   * LLMConfig fragment derived from the manifest: chosen backend plus mapped
+   * `session_defaults` (sampler hints; `max_output_tokens_min` applied as a
+   * floor). Spread it under your own overrides:
+   * `{ ...resolution.config, ...userConfig }`.
+   */
+  config: LLMConfig;
+  /**
+   * Complete channel array for `createLLM({ streamChannels })` — the
+   * manifest's channels merged over DEFAULT_CHANNELS, so passing it can never
+   * silently drop tool-call parsing.
+   */
+  streamChannels: StreamChannel[];
+  /** Verify the download against these (from HF LFS metadata). */
+  sha256?: string;
+  sizeBytes?: number;
+  contextLength?: number;
+  /** platform_notes + known_issues of the chosen variant — worth surfacing. */
+  notes: string[];
+  /** Why this variant/backend was chosen (for logs). */
+  reason: string;
+}
+
+/**
+ * Their `maxOutputTokens` floor semantics: `session_defaults.max_output_tokens_min`
+ * is a FLOOR (never a cap) — e.g. 2048 for reasoning models that need room to
+ * think before answering. Applied as max(packageDefault, floor) here; caller
+ * overrides win via `{ ...config, ...userConfig }`, so apply
+ * max(userValue, floor) yourself if you take user values.
+ */
+const DEFAULT_MAX_OUTPUT_TOKENS = 1024;
+
+/**
+ * Synchronous core of {@link resolveFromManifest} for an already-fetched
+ * manifest. Returns null when an explicitly requested backend is listed by no
+ * variant — fall back to your current (non-manifest) path in that case.
+ */
+export function resolutionFor(
+  manifest: Manifest,
+  opts: ResolveFromManifestOptions = {},
+): ManifestResolution | null {
+  const r = resolveVariant(manifest, opts);
+  if (!r) {
+    return null;
+  }
+
+  const config: LLMConfig = { backend: r.backend };
+  const sd = r.sessionDefaults ?? {};
+  if (typeof sd.max_output_tokens_min === "number") {
+    config.maxOutputTokens = Math.max(DEFAULT_MAX_OUTPUT_TOKENS, sd.max_output_tokens_min);
+  }
+  if (typeof sd.temperature === "number") {
+    config.temperature = sd.temperature;
+  }
+  if (typeof sd.top_k === "number") {
+    config.topK = sd.top_k;
+  }
+  if (typeof sd.top_p === "number") {
+    config.topP = sd.top_p;
+  }
+  // TODO(#23): decide whether context_length should seed maxContextTokens
+  // (model max vs engine budget are different knobs) and whether
+  // streamToolCalls should default on when the manifest declares channels.
+
+  return {
+    url: r.url,
+    file: r.file,
+    backend: r.backend,
+    config,
+    streamChannels: mergeStreamChannels(manifest),
+    sha256: r.variant.sha256,
+    sizeBytes: r.variant.size_bytes,
+    contextLength: r.contextLength,
+    notes: r.notes,
+    reason: r.reason,
+  };
+}
+
+/**
+ * Fetch `<repo>`'s manifest from the Hugging Face Hub and resolve the right
+ * variant for this device.
+ *
+ * ```ts
+ * const resolution = await resolveFromManifest("litert-community/LFM2.5-1.2B-Instruct");
+ * if (resolution) {
+ *   const llm = createLLM({ streamChannels: resolution.streamChannels });
+ *   await llm.loadModel(resolution.url, { ...resolution.config });
+ * }
+ * ```
+ *
+ * `platform` defaults to this device's OS when called through the package
+ * export (index.ts injects `Platform.OS`). Returns null when an explicitly
+ * requested backend is listed by no variant.
+ */
+export async function resolveFromManifest(
+  repo: string,
+  opts: ResolveFromManifestOptions = {},
+): Promise<ManifestResolution | null> {
+  const manifest = await fetchManifest(repo, opts.revision ?? "main");
+  return resolutionFor(manifest, opts);
+}


### PR DESCRIPTION
Addresses the resolver half of #23 — header read to follow, as agreed there.

## What this adds

- `resolveFromManifest(repo, opts?)` — fetches the repo's `litertlm_manifest.json` and returns `{ url, file, backend, config, streamChannels, sha256, sizeBytes, contextLength, sessionDefaults, notes, reason }`, ready for `createLLM({ streamChannels })` + `loadModel(url, config)`. `platform` defaults to `Platform.OS` (android / ios / macos / windows). **Never throws**: returns `null` when the repo ships no manifest (404), the `manifest_schema` is unsupported, the fetch fails or is aborted (`opts.signal`), or an explicitly requested backend is listed by no variant — so callers drop back onto today's path without a try/catch. Only the unexpected cases log one `console.warn` line; a missing manifest and a caller's own abort are silent.
- `mergeStreamChannels(manifest)` — the manifest's channels merged **over** `DEFAULT_CHANNELS`, so the default toolCall entry survives a manifest that declares only thinking (the footgun from the thread), and a manifest 0.1.1 model declaring its own tool markers overrides cleanly.
- An explicit `backend` is a filter, not a score — the cross-variant backend-loss case from #23 is a regression test here (`resolveVariant(lfm, { platform: 'android', backend: 'gpu' })` → the gpu re-export on gpu).
- `session_defaults` mapping: `max_output_tokens_min` applied as a floor over the 1024 default; `temperature`/`top_k`/`top_p` passed through; `notes` appended to `resolution.notes`; the raw object rides on `resolution.sessionDefaults`. Spread order `{ ...resolution.config, ...userConfig }` keeps user overrides on top.
- The core reader is vendored from john-rocky/hf-to-litertlm `readers/ts` v0.2.0 (`resolve` renamed `resolveVariant`; an optional `signal` and a status-carrying error added to `fetchManifest`) and stays react-native-free so jest covers it; `index.ts` injects the platform.

## Status

Typecheck, lint, and the full jest suite are green (24 tests in `manifestResolver.test.ts`; coverage thresholds pass). The two questions from the first round are closed as read in review — `context_length` does not seed `maxContextTokens`, and `streamToolCalls` stays off — with the reasoning recorded in the comment that replaced the TODO in `resolutionFor`. Still open, as a follow-up: a docs/website entry once the shape settles.

Happy to reshape anything — naming included.
