### PR TITLE
fix(android): abort in-flight generation with cancelProcess() on reset and cleanup

### DIFF
--- a/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
+++ b/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
@@ -11,6 +11,7 @@ import android.app.ActivityManager
 import android.content.Context
 import java.util.Collections
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
@@ -110,6 +111,10 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
     
     @Volatile
     private var isClosed = false
+
+    /** Latch of the in-flight streaming worker, if any. Used to wait for cancellation to settle. */
+    @Volatile
+    private var activeStreamingLatch: CountDownLatch? = null
 
     private val modelStore = HybridModelStore()
     private var loadedModelPath: String? = null
@@ -474,12 +479,9 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
     }
 
     override fun resetConversation(historyJson: String?, systemPrompt: String?) {
-        // Signal the native inference thread to stop — cancelProcess() is safe
-        // to call from any thread and returns immediately.  Without this, an
-        // in-flight sendMessageAsync keeps generating until EOS/maxTokens even
-        // after the Conversation is closed, blocking the Promise.parallel worker.
-        try { conversation?.cancelProcess() }
-        catch (e: Exception) { Log.w(TAG, "resetConversation — cancelProcess error: ${e.message}") }
+        // Signal native inference to cancel and await the in-flight streaming
+        // worker to settle before closing the conversation underneath it.
+        cancelInFlightGeneration()
         synchronized(history) {
             history.clear()
             // Mirror the replayed transcript into the wrapper's own history so
@@ -661,12 +663,32 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
         cleanupInternal()
     }
 
+    /**
+     * Signals the native inference thread to cancel and awaits the in-flight
+     * streaming worker to settle before closing or deleting the conversation.
+     * Prevents native race conditions where close() deletes native conversation
+     * state while the decode loop is still running on a background worker thread.
+     */
+    private fun cancelInFlightGeneration() {
+        try {
+            conversation?.cancelProcess()
+            val latch = activeStreamingLatch
+            if (latch != null) {
+                val settled = latch.await(2, TimeUnit.SECONDS)
+                if (!settled) {
+                    Log.w(TAG, "cancelInFlightGeneration: worker did not settle within timeout")
+                }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "cancelInFlightGeneration error: ${e.message}")
+        }
+    }
+
     private fun cleanupInternal() {
         synchronized(initLock) {
             try {
-                // Safety net: signal stop in case stopGeneration was not called before close
-                try { conversation?.cancelProcess() }
-                catch (_: Exception) { /* best-effort */ }
+                // Abort any in-flight generation and let worker settle before close
+                cancelInFlightGeneration()
                 conversation?.close()
                 conversation = null
                 engine?.close()        // Direct call
@@ -939,6 +961,7 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
                 if (onToken != null) {
                     // ── Streaming path ────────────────────────────────────────────────
                     val latch = CountDownLatch(1)
+                    activeStreamingLatch = latch
                     val errorRef = AtomicReference<Throwable?>(null)
                     val fullResponseBuilder = StringBuilder()
 
@@ -955,26 +978,32 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
                     )
 
                     try {
-                        conversation!!.sendMessageAsync(
-                            message = userMsg,
-                            callback = listener,
-                            repetitionPenaltyConfig = repetitionPenaltyConfig,
-                            noRepeatNgramConfig = noRepeatNgramConfig,
-                            suppressTokensConfig = suppressTokensConfig,
-                            maxOutputToken = perCallMaxOutput,
-                            thinkingConfig = perCallThinking,
-                            responseFormat = responseFormat,
-                        )
-                    } catch (e: Exception) {
-                        Log.e(TAG, "execute streaming failed", e)
-                        errorRef.set(e)
-                        onToken("Error: ${e.message}", true)
-                        latch.countDown()
-                    }
+                        try {
+                            conversation!!.sendMessageAsync(
+                                message = userMsg,
+                                callback = listener,
+                                repetitionPenaltyConfig = repetitionPenaltyConfig,
+                                noRepeatNgramConfig = noRepeatNgramConfig,
+                                suppressTokensConfig = suppressTokensConfig,
+                                maxOutputToken = perCallMaxOutput,
+                                thinkingConfig = perCallThinking,
+                                responseFormat = responseFormat,
+                            )
+                        } catch (e: Exception) {
+                            Log.e(TAG, "execute streaming failed", e)
+                            errorRef.set(e)
+                            onToken("Error: ${e.message}", true)
+                            latch.countDown()
+                        }
 
-                    latch.await()
-                    errorRef.get()?.let { throw RuntimeException("execute streaming failed: ${it.message}", it) }
-                    fullResponseBuilder.toString()
+                        latch.await()
+                        errorRef.get()?.let { throw RuntimeException("execute streaming failed: ${it.message}", it) }
+                        fullResponseBuilder.toString()
+                    } finally {
+                        if (activeStreamingLatch === latch) {
+                            activeStreamingLatch = null
+                        }
+                    }
 
                 } else {
                     // ── Blocking path ─────────────────────────────────────────────────

--- a/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
+++ b/android/src/main/java/com/margelo/nitro/dev/litert/litertlm/HybridLiteRTLM.kt
@@ -474,6 +474,12 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
     }
 
     override fun resetConversation(historyJson: String?, systemPrompt: String?) {
+        // Signal the native inference thread to stop — cancelProcess() is safe
+        // to call from any thread and returns immediately.  Without this, an
+        // in-flight sendMessageAsync keeps generating until EOS/maxTokens even
+        // after the Conversation is closed, blocking the Promise.parallel worker.
+        try { conversation?.cancelProcess() }
+        catch (e: Exception) { Log.w(TAG, "resetConversation — cancelProcess error: ${e.message}") }
         synchronized(history) {
             history.clear()
             // Mirror the replayed transcript into the wrapper's own history so
@@ -658,6 +664,9 @@ class HybridLiteRTLM : HybridLiteRTLMSpec() {
     private fun cleanupInternal() {
         synchronized(initLock) {
             try {
+                // Safety net: signal stop in case stopGeneration was not called before close
+                try { conversation?.cancelProcess() }
+                catch (_: Exception) { /* best-effort */ }
                 conversation?.close()
                 conversation = null
                 engine?.close()        // Direct call


### PR DESCRIPTION
### Summary
    Calls `conversation?.cancelProcess()` and awaits the active streaming worker to settle before closing or recreating conversations in `resetConversation()` and  `cleanupInternal()`.

### Problem
    In the LiteRT-LM Android Kotlin SDK, calling `Conversation.close()` or discarding the reference while an asynchronous generation (`sendMessageAsync`) is active  does not immediately interrupt the native inference thread. The model continues computing tokens in the background until reaching EOS or `maxOutputTokens`.

    This causes two issues:
    1. When cancelling text generation (e.g., via `resetConversation()`), background compute continues burning GPU/CPU and consuming battery.
    2. Subsequent `execute()` or `sendMessage()` requests are delayed or race with the still-running worker thread.
    3. Invoking `.close()` while the decode loop is still running in C++ can trigger ordering hazards or segmentation faults.

### Solution
    1. Introduce a thread-safe helper `cancelInFlightGeneration()` that signals `conversation?.cancelProcess()` to stop the native decode loop.
    2. Maintain an `@Volatile activeStreamingLatch` reference to await the in-flight streaming worker (with a 2-second timeout) so the thread settles cleanly before  `conversation?.close()` is executed.
    3. Call `cancelInFlightGeneration()` in:
       - `resetConversation()` before clearing history and creating a new session.
       - `cleanupInternal()` before tearing down conversation and engine handles.

### Behavioral Note
    Because the underlying LiteRT SDK reports cancellation via `onError`, an in-flight `execute()` that is cancelled will reject with a cancellation error (and emit an  `Error: ...` chunk with `done = true`) rather than silently resolving to EOS.

### Testing
    - Tested on Android with on-device model inference.
    - Verified that calling `resetConversation()` mid-stream immediately halts token production and frees the execution thread without crashes or hangs.